### PR TITLE
feat: add multilingual voice output and stronger direct-open intent handling

### DIFF
--- a/backend/src/openapi.js
+++ b/backend/src/openapi.js
@@ -25,7 +25,8 @@ const baseSpec = {
   tags: [
     { name: 'Health', description: 'Service status endpoints' },
     { name: 'Settings', description: 'Runtime backend settings' },
-    { name: 'Summarization', description: 'Page summarization endpoints' }
+    { name: 'Summarization', description: 'Page summarization endpoints' },
+    { name: 'Speech', description: 'Voice transcription endpoints' }
   ],
   paths: {
     '/health': {
@@ -146,6 +147,82 @@ const baseSpec = {
           }
         }
       }
+    },
+    '/api/transcribe': {
+      post: {
+        tags: ['Speech'],
+        summary: 'Transcribe a short voice command',
+        description:
+          'Accepts a short base64-encoded audio clip and returns the transcript text plus detected input language.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/TranscribeRequest' }
+            }
+          }
+        },
+        responses: {
+          200: {
+            description: 'Transcription result',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/TranscribeResponse' }
+              }
+            }
+          },
+          400: {
+            description: 'Bad request',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' }
+              }
+            }
+          },
+          503: {
+            description: 'Transcription backend unavailable',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/api/translate-messages': {
+      post: {
+        tags: ['Speech'],
+        summary: 'Translate Navable UI messages',
+        description:
+          'Accepts a message catalog and returns the same keys translated into the requested language.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/TranslateMessagesRequest' }
+            }
+          }
+        },
+        responses: {
+          200: {
+            description: 'Translated message catalog',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/TranslateMessagesResponse' }
+              }
+            }
+          },
+          400: {
+            description: 'Bad request',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' }
+              }
+            }
+          }
+        }
+      }
     }
   },
   components: {
@@ -200,6 +277,10 @@ const baseSpec = {
             type: 'string',
             description: 'Optional user command (any language).'
           },
+          outputLanguage: {
+            type: 'string',
+            description: 'Preferred language for Navable-authored summary output.'
+          },
           pageStructure: { $ref: '#/components/schemas/PageStructure' }
         }
       },
@@ -213,17 +294,70 @@ const baseSpec = {
           plan: { $ref: '#/components/schemas/Plan' }
         }
       },
+      TranscribeRequest: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['audioBase64'],
+        properties: {
+          audioBase64: {
+            type: 'string',
+            description: 'Base64-encoded short audio clip (for example webm/opus).'
+          },
+          mimeType: {
+            type: 'string',
+            description: 'Optional MIME type for the uploaded audio clip.'
+          }
+        }
+      },
+      TranscribeResponse: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['text', 'language'],
+        properties: {
+          text: { type: 'string' },
+          language: { type: 'string' }
+        }
+      },
+      TranslateMessagesRequest: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['language', 'messages'],
+        properties: {
+          language: {
+            type: 'string',
+            description: 'Target language code for the translated output.'
+          },
+          messages: {
+            type: 'object',
+            additionalProperties: { type: 'string' },
+            description: 'Flat message catalog to translate.'
+          }
+        }
+      },
+      TranslateMessagesResponse: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['language', 'messages'],
+        properties: {
+          language: { type: 'string' },
+          messages: {
+            type: 'object',
+            additionalProperties: { type: 'string' }
+          }
+        }
+      },
       Settings: {
         type: 'object',
         additionalProperties: false,
-        required: ['aiEnabled', 'model'],
+        required: ['aiEnabled', 'model', 'transcriptionModel'],
         properties: {
           aiEnabled: {
             type: 'boolean',
             description:
               'When false, /api/summarize skips OpenAI and uses local fallback.'
           },
-          model: { type: 'string', description: 'OpenAI model ID.' }
+          model: { type: 'string', description: 'OpenAI model ID for summaries.' },
+          transcriptionModel: { type: 'string', description: 'OpenAI model ID for voice transcription.' }
         }
       },
       UpdateSettingsRequest: {
@@ -231,7 +365,8 @@ const baseSpec = {
         additionalProperties: false,
         properties: {
           aiEnabled: { type: 'boolean' },
-          model: { type: 'string' }
+          model: { type: 'string' },
+          transcriptionModel: { type: 'string' }
         }
       }
     }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
-import OpenAI from 'openai';
+import OpenAI, { toFile } from 'openai';
 import swaggerUi from 'swagger-ui-express';
 import { getOpenApiSpec } from './openapi.js';
 
@@ -11,7 +11,7 @@ const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(cors());
-app.use(express.json({ limit: '1mb' }));
+app.use(express.json({ limit: '5mb' }));
 
 app.get('/api-docs.json', (req, res) => {
   res.json(getOpenApiSpec(req));
@@ -44,27 +44,222 @@ const ALLOWED_ACTIONS = new Set([
 
 const DEFAULT_SETTINGS = {
   aiEnabled: true,
-  model: 'gpt-4.1-mini'
+  model: 'gpt-4.1-mini',
+  transcriptionModel: 'gpt-4o-mini-transcribe'
 };
 
 let runtimeSettings = { ...DEFAULT_SETTINGS };
+const translatedCatalogCache = new Map();
 
-function buildFallbackSummary(structure) {
-  if (!structure) return 'No page data available.';
+const OUTPUT_MESSAGES = {
+  en: {
+    no_page_data: 'No page data available.',
+    title_value: 'Title {value}.',
+    counts_value: 'Headings {headings}, links {links}, buttons {buttons}.',
+    top_heading: 'Top heading: {value}.',
+    suggestion_scroll: 'Try: scroll down.',
+    suggestion_title: 'Try: read the title.',
+    suggestion_heading: 'Try: move to the next heading.',
+    suggestion_open_link: 'Try: open first link.'
+  },
+  fr: {
+    no_page_data: 'Aucune donnee de page disponible.',
+    title_value: 'Titre {value}.',
+    counts_value: 'Titres {headings}, liens {links}, boutons {buttons}.',
+    top_heading: 'Titre principal : {value}.',
+    suggestion_scroll: 'Essayez : fais defiler vers le bas.',
+    suggestion_title: 'Essayez : lis le titre.',
+    suggestion_heading: 'Essayez : va au titre suivant.',
+    suggestion_open_link: 'Essayez : ouvre le premier lien.'
+  },
+  ar: {
+    no_page_data: 'لا توجد بيانات متاحة عن الصفحة.',
+    title_value: 'العنوان {value}.',
+    counts_value: 'العناوين {headings}، الروابط {links}، الأزرار {buttons}.',
+    top_heading: 'أعلى عنوان: {value}.',
+    suggestion_scroll: 'جرّب: مرر إلى الأسفل.',
+    suggestion_title: 'جرّب: اقرأ العنوان.',
+    suggestion_heading: 'جرّب: انتقل إلى العنوان التالي.',
+    suggestion_open_link: 'جرّب: افتح أول رابط.'
+  }
+};
+
+function canonicalizeLocale(lang) {
+  const raw = String(lang || '').trim().replace(/_/g, '-');
+  if (!raw) return '';
+  try {
+    return new Intl.Locale(raw).baseName;
+  } catch {
+    const parts = raw.split('-').filter(Boolean);
+    if (!parts.length) return '';
+    parts[0] = parts[0].toLowerCase();
+    for (let i = 1; i < parts.length; i += 1) {
+      if (parts[i].length === 2) parts[i] = parts[i].toUpperCase();
+      else if (parts[i].length === 4) parts[i] = parts[i][0].toUpperCase() + parts[i].slice(1).toLowerCase();
+      else parts[i] = parts[i].toLowerCase();
+    }
+    return parts.join('-');
+  }
+}
+
+function normalizeOutputLanguage(lang) {
+  const canonical = canonicalizeLocale(lang);
+  if (!canonical) return 'en';
+  const primary = canonical.split('-')[0].toLowerCase();
+  return primary || 'en';
+}
+
+function interpolate(template, params = {}) {
+  return String(template || '').replace(/\{(\w+)\}/g, (_match, name) => (
+    Object.prototype.hasOwnProperty.call(params, name) ? String(params[name]) : ''
+  ));
+}
+
+function sanitizeTranslatedCatalog(candidate, fallbackCatalog) {
+  return Object.keys(fallbackCatalog || {}).reduce((acc, key) => {
+    const value = candidate && Object.prototype.hasOwnProperty.call(candidate, key)
+      ? candidate[key]
+      : null;
+    acc[key] = typeof value === 'string' && value.trim() ? value : fallbackCatalog[key];
+    return acc;
+  }, {});
+}
+
+function catalogCacheKey(language, messages) {
+  const ordered = Object.keys(messages || {}).sort().reduce((acc, key) => {
+    acc[key] = messages[key];
+    return acc;
+  }, {});
+  return `${normalizeOutputLanguage(language)}|${JSON.stringify(ordered)}`;
+}
+
+function localCatalogForLanguage(messageCatalogs, lang) {
+  const normalized = normalizeOutputLanguage(lang);
+  return messageCatalogs[normalized] || null;
+}
+
+async function callOpenAiTranslateMessages(messages, outputLanguage, settings = DEFAULT_SETTINGS) {
+  const client = getOpenAiClient();
+  if (!client) return null;
+
+  const model = settings.model || DEFAULT_SETTINGS.model;
+  const targetLanguage = normalizeOutputLanguage(outputLanguage);
+  const completion = await client.chat.completions.create({
+    model,
+    response_format: { type: 'json_object' },
+    messages: [
+      {
+        role: 'system',
+        content: [
+          'You translate short browser-extension UI messages.',
+          `Translate every value into "${targetLanguage}".`,
+          'Return exactly one JSON object with the same keys as the input.',
+          'Do not add or remove keys.',
+          'Preserve placeholders like {value}, {target}, {name} exactly as written.',
+          'Keep the same concise tone and sentence intent.'
+        ].join('\n')
+      },
+      {
+        role: 'user',
+        content: JSON.stringify({
+          language: targetLanguage,
+          messages
+        })
+      }
+    ]
+  });
+
+  const raw = completion.choices?.[0]?.message?.content || '{}';
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = {};
+  }
+  return sanitizeTranslatedCatalog(parsed, messages);
+}
+
+async function getTranslatedCatalog(messages, outputLanguage, settings = DEFAULT_SETTINGS) {
+  const targetLanguage = normalizeOutputLanguage(outputLanguage);
+  if (!messages || typeof messages !== 'object' || Array.isArray(messages)) return {};
+  if (!targetLanguage || targetLanguage === 'en') return { ...messages };
+
+  const cacheKey = catalogCacheKey(targetLanguage, messages);
+  if (translatedCatalogCache.has(cacheKey)) {
+    return translatedCatalogCache.get(cacheKey);
+  }
+
+  let translated = null;
+  try {
+    translated = await callOpenAiTranslateMessages(messages, targetLanguage, settings);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[Navable backend] OpenAI UI translation error:', err);
+  }
+
+  const safe = sanitizeTranslatedCatalog(translated, messages);
+  translatedCatalogCache.set(cacheKey, safe);
+  return safe;
+}
+
+async function getOutputCatalog(outputLanguage, settings = DEFAULT_SETTINGS) {
+  const localCatalog = localCatalogForLanguage(OUTPUT_MESSAGES, outputLanguage);
+  if (localCatalog) return localCatalog;
+  return getTranslatedCatalog(OUTPUT_MESSAGES.en, outputLanguage, settings);
+}
+
+function outputMessageFromCatalog(key, catalog, params = {}) {
+  const template = (catalog && catalog[key]) || OUTPUT_MESSAGES.en[key] || key;
+  return interpolate(template, params);
+}
+
+function outputMessage(key, lang, params = {}, catalog) {
+  const dictionary = catalog || localCatalogForLanguage(OUTPUT_MESSAGES, lang) || OUTPUT_MESSAGES.en;
+  return outputMessageFromCatalog(key, dictionary, params);
+}
+
+function detectTranscriptLanguage(text) {
+  const raw = String(text || '').trim();
+  if (!raw) return '';
+  if (/[\u0600-\u06FF]/.test(raw)) return 'ar';
+
+  const lower = raw.toLowerCase();
+  let frenchScore = 0;
+  let englishScore = 0;
+
+  if (/[àâçéèêëîïôûùüÿœæ]/i.test(raw)) frenchScore += 3;
+  frenchScore += (lower.match(/\b(bonjour|salut|merci|ouvre|ouvrir|recherche|cherche|resume|résume|résumé|decris|décris|titre|page|lien|bouton|suivant|precedent|précédent|aide|ecoute|écoute)\b/g) || []).length;
+  englishScore += (lower.match(/\b(open|search|scroll|summary|summarize|describe|title|button|link|page|help|listen|stop|start|next|previous|focus|activate)\b/g) || []).length;
+
+  if (frenchScore > englishScore && frenchScore > 0) return 'fr';
+  if (englishScore > frenchScore && englishScore > 0) return 'en';
+  return '';
+}
+
+function buildFallbackSummary(structure, outputLanguage, catalog) {
+  if (!structure) return outputMessage('no_page_data', outputLanguage, {}, catalog);
   const counts = structure.counts || {};
-  const titlePart = structure.title ? `Title ${structure.title}. ` : '';
-  const basics = `Headings ${counts.headings || 0}, links ${counts.links || 0}, buttons ${counts.buttons || 0}.`;
+  const titlePart = structure.title ? `${outputMessage('title_value', outputLanguage, { value: structure.title }, catalog)} ` : '';
+  const basics = outputMessage('counts_value', outputLanguage, {
+    headings: counts.headings || 0,
+    links: counts.links || 0,
+    buttons: counts.buttons || 0
+  }, catalog);
   const firstHeading =
     structure.headings && structure.headings.length
-      ? `Top heading: ${structure.headings[0].label}.`
+      ? outputMessage('top_heading', outputLanguage, { value: structure.headings[0].label }, catalog)
       : '';
   return [titlePart + basics, firstHeading].filter(Boolean).join(' ');
 }
 
-function buildFallbackSuggestions(structure) {
-  const suggestions = ['Try: scroll down.', 'Try: read the title.', 'Try: move to the next heading.'];
+function buildFallbackSuggestions(structure, outputLanguage, catalog) {
+  const suggestions = [
+    outputMessage('suggestion_scroll', outputLanguage, {}, catalog),
+    outputMessage('suggestion_title', outputLanguage, {}, catalog),
+    outputMessage('suggestion_heading', outputLanguage, {}, catalog)
+  ];
   if (structure && structure.links && structure.links.length) {
-    suggestions.push('Try: open first link.');
+    suggestions.push(outputMessage('suggestion_open_link', outputLanguage, {}, catalog));
   }
   return suggestions;
 }
@@ -84,13 +279,19 @@ function sanitizePlan(rawPlan) {
   return { steps };
 }
 
-async function callOpenAiSummarize(command, pageStructure, settings = DEFAULT_SETTINGS) {
+function getOpenAiClient() {
   const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey || settings.aiEnabled === false) {
+  if (!apiKey) return null;
+  return new OpenAI({ apiKey });
+}
+
+async function callOpenAiSummarize(command, pageStructure, settings = DEFAULT_SETTINGS, outputLanguage = 'en') {
+  if (settings.aiEnabled === false) {
     return null;
   }
 
-  const client = new OpenAI({ apiKey });
+  const client = getOpenAiClient();
+  if (!client) return null;
   // Use the cheapest suitable model for short page summaries.
   const model = settings.model || DEFAULT_SETTINGS.model;
 
@@ -99,6 +300,7 @@ async function callOpenAiSummarize(command, pageStructure, settings = DEFAULT_SE
     'You receive a structured snapshot of a web page as JSON (pageStructure) and an optional user command string.',
     'pageStructure.excerpt may contain up to ~1200 characters of visible page text; prefer it for detail.',
     'pageStructure includes counts, headings, links, buttons, landmarks, activeLabel (focused element), lang, and URL.',
+    `You must answer in outputLanguage "${normalizeOutputLanguage(outputLanguage)}" unless the user command explicitly requests another output language.`,
     'Your job for a blind user:',
     '- Give a concise orientation: 2–4 short sentences on what the page is, key sections/headings/controls, and any focused element worth noting.',
     '- Then provide 2–5 next actions as a numbered list of short, actionable items.',
@@ -127,7 +329,8 @@ async function callOpenAiSummarize(command, pageStructure, settings = DEFAULT_SE
 
   const userContent = JSON.stringify({
     command: command || 'Summarize this page for a blind user.',
-    pageStructure
+    pageStructure,
+    outputLanguage: normalizeOutputLanguage(outputLanguage)
   });
 
   const completion = await client.chat.completions.create({
@@ -154,6 +357,40 @@ async function callOpenAiSummarize(command, pageStructure, settings = DEFAULT_SE
   };
 }
 
+async function callOpenAiTranscribe(audioBase64, mimeType, settings = DEFAULT_SETTINGS) {
+  const client = getOpenAiClient();
+  if (!client) return null;
+
+  const buffer = Buffer.from(String(audioBase64 || ''), 'base64');
+  if (!buffer.length) {
+    throw new Error('Empty audio payload');
+  }
+
+  const extension = mimeType && String(mimeType).includes('ogg')
+    ? 'ogg'
+    : mimeType && String(mimeType).includes('mp4')
+      ? 'mp4'
+      : 'webm';
+  const audioFile = await toFile(buffer, `navable-voice.${extension}`, {
+    type: mimeType || 'audio/webm'
+  });
+
+  const transcription = await client.audio.transcriptions.create({
+    file: audioFile,
+    model: settings.transcriptionModel || DEFAULT_SETTINGS.transcriptionModel,
+    response_format: 'json',
+    chunking_strategy: 'auto'
+  });
+
+  return {
+    text: transcription && transcription.text ? String(transcription.text) : '',
+    language:
+      transcription && transcription.language
+        ? String(transcription.language)
+        : detectTranscriptLanguage(transcription && transcription.text ? transcription.text : '')
+  };
+}
+
 app.get('/health', (_req, res) => {
   res.json({ ok: true });
 });
@@ -168,7 +405,7 @@ app.put('/api/settings', (req, res) => {
     return res.status(400).json({ error: 'Invalid JSON body' });
   }
 
-  const allowedKeys = new Set(['aiEnabled', 'model']);
+  const allowedKeys = new Set(['aiEnabled', 'model', 'transcriptionModel']);
   const unknownKeys = Object.keys(body).filter((key) => !allowedKeys.has(key));
   if (unknownKeys.length) {
     return res
@@ -192,6 +429,13 @@ app.put('/api/settings', (req, res) => {
     updates.model = body.model.trim();
   }
 
+  if (Object.prototype.hasOwnProperty.call(body, 'transcriptionModel')) {
+    if (typeof body.transcriptionModel !== 'string' || !body.transcriptionModel.trim()) {
+      return res.status(400).json({ error: 'transcriptionModel must be a non-empty string' });
+    }
+    updates.transcriptionModel = body.transcriptionModel.trim();
+  }
+
   runtimeSettings = { ...runtimeSettings, ...updates };
   res.json(runtimeSettings);
 });
@@ -201,30 +445,93 @@ app.delete('/api/settings', (_req, res) => {
   res.json(runtimeSettings);
 });
 
+app.post('/api/transcribe', async (req, res) => {
+  try {
+    const { audioBase64, mimeType } = req.body || {};
+    if (!audioBase64 || typeof audioBase64 !== 'string') {
+      return res.status(400).json({ error: 'Missing audioBase64' });
+    }
+
+    let result = null;
+    try {
+      result = await callOpenAiTranscribe(audioBase64, mimeType, runtimeSettings);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[Navable backend] OpenAI transcription error:', err);
+    }
+
+    if (!result) {
+      return res.status(503).json({ error: 'Transcription unavailable' });
+    }
+
+    res.json({
+      text: result.text || '',
+      language: result.language || ''
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[Navable backend] /api/transcribe error:', err);
+    res.status(500).json({ error: 'Transcription failed' });
+  }
+});
+
+app.post('/api/translate-messages', async (req, res) => {
+  try {
+    const { language, messages } = req.body || {};
+    if (!language || typeof language !== 'string') {
+      return res.status(400).json({ error: 'Missing language' });
+    }
+    if (!messages || typeof messages !== 'object' || Array.isArray(messages)) {
+      return res.status(400).json({ error: 'Missing messages object' });
+    }
+
+    const sourceMessages = Object.keys(messages).reduce((acc, key) => {
+      if (typeof messages[key] === 'string') acc[key] = messages[key];
+      return acc;
+    }, {});
+
+    if (!Object.keys(sourceMessages).length) {
+      return res.status(400).json({ error: 'Messages object must contain string values' });
+    }
+
+    const translated = await getTranslatedCatalog(sourceMessages, language, runtimeSettings);
+    res.json({
+      language: normalizeOutputLanguage(language),
+      messages: translated
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[Navable backend] /api/translate-messages error:', err);
+    res.status(500).json({ error: 'Message translation failed' });
+  }
+});
+
 app.post('/api/summarize', async (req, res) => {
   try {
-    const { command, pageStructure } = req.body || {};
+    const { command, pageStructure, outputLanguage } = req.body || {};
     if (!pageStructure) {
       return res.status(400).json({ error: 'Missing pageStructure' });
     }
 
     const structure = pageStructure;
+    const resolvedOutputLanguage = normalizeOutputLanguage(outputLanguage);
 
     let result = null;
     try {
-      result = await callOpenAiSummarize(command, structure, runtimeSettings);
+      result = await callOpenAiSummarize(command, structure, runtimeSettings, resolvedOutputLanguage);
     } catch (err) {
       // Failed OpenAI call; fall back to local summary.
       // eslint-disable-next-line no-console
       console.error('[Navable backend] OpenAI error:', err);
     }
 
+    const outputCatalog = await getOutputCatalog(resolvedOutputLanguage, runtimeSettings);
     const friendlySummary =
-      (result && result.friendlySummary) || buildFallbackSummary(structure);
+      (result && result.friendlySummary) || buildFallbackSummary(structure, resolvedOutputLanguage, outputCatalog);
     const suggestions =
       (result && result.suggestions && result.suggestions.length
         ? result.suggestions
-        : buildFallbackSuggestions(structure));
+        : buildFallbackSuggestions(structure, resolvedOutputLanguage, outputCatalog));
     const plan =
       (result && result.plan && Array.isArray(result.plan.steps)
         ? sanitizePlan(result.plan)

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -13,7 +13,7 @@
   "content_scripts": [
     {
       "matches": ["https://*/*", "http://*/*"],
-      "js": ["src/common/announce.js", "src/common/speech.js", "src/content.js"],
+      "js": ["src/common/i18n.js", "src/common/announce.js", "src/common/speech.js", "src/content.js"],
       "run_at": "document_idle"
     }
   ],

--- a/dist/src/background.js
+++ b/dist/src/background.js
@@ -84,6 +84,150 @@ const NAVABLE_NEW_TAB_URL = (() => {
   }
 })();
 
+const TRANSLATE_MESSAGES_URL = 'http://localhost:3000/api/translate-messages';
+const OUTPUT_LOCALES = {
+  en: 'en-US',
+  fr: 'fr-FR',
+  ar: 'ar-SA'
+};
+const outputMessageLoadPromises = {};
+
+const OUTPUT_MESSAGES = {
+  en: {
+    summary_unavailable: 'Page summary is unavailable.',
+    no_title: 'No title found.',
+    title_value: 'Title: {value}.',
+    counts_value: 'Headings {headings}, links {links}, buttons {buttons}.',
+    top_heading: 'Top heading: {value}.',
+    excerpt_value: 'Page snippet: {value}.',
+    try_commands: 'Try commands like: describe this page, scroll down, read title, read heading.',
+    ai_summaries_off: 'AI summaries are off. Enable AI in options for a richer summary.',
+    suggestion_scroll: 'Try: scroll down.',
+    suggestion_title: 'Try: read the title.',
+    suggestion_heading: 'Try: move to the next heading.',
+    suggestion_open_link: 'Try: open first link.',
+    opening_value: 'Opening {value}.',
+    open_website_failed: 'Could not open that website.',
+    missing_url: 'Missing website name or URL.'
+  },
+  fr: {
+    summary_unavailable: 'Le resume de la page n est pas disponible.',
+    no_title: 'Aucun titre trouve.',
+    title_value: 'Titre : {value}.',
+    counts_value: 'Titres {headings}, liens {links}, boutons {buttons}.',
+    top_heading: 'Titre principal : {value}.',
+    excerpt_value: 'Extrait de la page : {value}.',
+    try_commands: 'Essayez des commandes comme : decris cette page, fais defiler vers le bas, lis le titre, lis le titre suivant.',
+    ai_summaries_off: 'Les resumes IA sont desactives. Activez l IA dans les options pour un resume plus riche.',
+    suggestion_scroll: 'Essayez : fais defiler vers le bas.',
+    suggestion_title: 'Essayez : lis le titre.',
+    suggestion_heading: 'Essayez : va au titre suivant.',
+    suggestion_open_link: 'Essayez : ouvre le premier lien.',
+    opening_value: 'Ouverture de {value}.',
+    open_website_failed: 'Impossible d ouvrir ce site.',
+    missing_url: 'Nom du site ou URL manquant.'
+  },
+  ar: {
+    summary_unavailable: 'ملخص الصفحة غير متاح.',
+    no_title: 'لم يتم العثور على عنوان.',
+    title_value: 'العنوان: {value}.',
+    counts_value: 'العناوين {headings}، الروابط {links}، الأزرار {buttons}.',
+    top_heading: 'أعلى عنوان: {value}.',
+    excerpt_value: 'مقتطف من الصفحة: {value}.',
+    try_commands: 'جرّب أوامر مثل: صف هذه الصفحة، مرر للأسفل، اقرأ العنوان، اقرأ العنوان التالي.',
+    ai_summaries_off: 'ملخصات الذكاء الاصطناعي متوقفة. فعّل الذكاء الاصطناعي من الإعدادات للحصول على ملخص أفضل.',
+    suggestion_scroll: 'جرّب: مرر إلى الأسفل.',
+    suggestion_title: 'جرّب: اقرأ العنوان.',
+    suggestion_heading: 'جرّب: انتقل إلى العنوان التالي.',
+    suggestion_open_link: 'جرّب: افتح أول رابط.',
+    opening_value: 'جارٍ فتح {value}.',
+    open_website_failed: 'تعذر فتح هذا الموقع.',
+    missing_url: 'اسم الموقع أو الرابط مفقود.'
+  }
+};
+
+function normalizeOutputLanguage(lang) {
+  const raw = String(lang || '').trim().replace(/_/g, '-');
+  if (!raw) return 'en';
+  try {
+    const canonical = new Intl.Locale(raw).baseName;
+    return canonical.split('-')[0].toLowerCase() || 'en';
+  } catch (_err) {
+    return raw.toLowerCase().split(/[-_]/)[0] || 'en';
+  }
+}
+
+function canonicalizeLocale(lang) {
+  const raw = String(lang || '').trim().replace(/_/g, '-');
+  if (!raw) return '';
+  try {
+    return new Intl.Locale(raw).baseName;
+  } catch (_err) {
+    const parts = raw.split('-').filter(Boolean);
+    if (!parts.length) return '';
+    parts[0] = parts[0].toLowerCase();
+    for (let i = 1; i < parts.length; i += 1) {
+      if (parts[i].length === 2) parts[i] = parts[i].toUpperCase();
+      else if (parts[i].length === 4) parts[i] = parts[i][0].toUpperCase() + parts[i].slice(1).toLowerCase();
+      else parts[i] = parts[i].toLowerCase();
+    }
+    return parts.join('-');
+  }
+}
+
+function sanitizeOutputMessages(candidate, fallbackDictionary) {
+  return Object.keys(fallbackDictionary).reduce((acc, key) => {
+    const value = candidate && Object.prototype.hasOwnProperty.call(candidate, key)
+      ? candidate[key]
+      : null;
+    acc[key] = typeof value === 'string' && value.trim() ? value : fallbackDictionary[key];
+    return acc;
+  }, {});
+}
+
+function ensureOutputMessages(lang) {
+  const normalized = normalizeOutputLanguage(lang);
+  if (!normalized || normalized === 'en' || OUTPUT_MESSAGES[normalized]) {
+    return Promise.resolve(OUTPUT_MESSAGES[normalized] || OUTPUT_MESSAGES.en);
+  }
+  if (outputMessageLoadPromises[normalized]) return outputMessageLoadPromises[normalized];
+
+  outputMessageLoadPromises[normalized] = fetch(TRANSLATE_MESSAGES_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      language: normalized,
+      messages: OUTPUT_MESSAGES.en
+    })
+  }).then((response) => {
+    if (!response.ok) throw new Error(`Translation failed with status ${response.status}`);
+    return response.json();
+  }).then((payload) => {
+    OUTPUT_MESSAGES[normalized] = sanitizeOutputMessages(payload?.messages, OUTPUT_MESSAGES.en);
+    return OUTPUT_MESSAGES[normalized];
+  }).catch(() => OUTPUT_MESSAGES.en).finally(() => {
+    delete outputMessageLoadPromises[normalized];
+  });
+
+  return outputMessageLoadPromises[normalized];
+}
+
+function outputLocale(lang) {
+  const normalized = normalizeOutputLanguage(lang);
+  if (OUTPUT_LOCALES[normalized]) return OUTPUT_LOCALES[normalized];
+  return canonicalizeLocale(lang) || normalized || OUTPUT_LOCALES.en;
+}
+
+function outputMessage(key, lang, params = {}) {
+  const normalized = normalizeOutputLanguage(lang);
+  const dictionary = OUTPUT_MESSAGES[normalized] || OUTPUT_MESSAGES.en;
+  const fallback = OUTPUT_MESSAGES.en;
+  const template = dictionary[key] || fallback[key] || key;
+  return String(template).replace(/\{(\w+)\}/g, (_match, name) => (
+    Object.prototype.hasOwnProperty.call(params, name) ? String(params[name]) : ''
+  ));
+}
+
 function isInternalNewTabUrl(url) {
   const u = String(url || '');
   if (!u) return false;
@@ -130,30 +274,182 @@ async function tryExecutePlan(plan) {
   return false;
 }
 
-function stubPlanner(command, structure) {
+const INTENT_STOPWORDS = new Set([
+  'a', 'an', 'the', 'me', 'to', 'for', 'please', 'can', 'could', 'would', 'you',
+  'show', 'take', 'bring', 'go', 'move', 'open', 'visit', 'launch', 'scroll', 'read',
+  'tell', 'what', 'is', 'my', 'current', 'this', 'that', 'of', 'on', 'in', 'at',
+  'page', 'section', 'heading', 'link', 'button', 'item', 'tab', 'website', 'site',
+  'le', 'la', 'les', 'de', 'des', 'du', 'un', 'une', 'moi', 'mon', 'ma', 'mes', 'sur',
+  'ici', 'cette', 'ce', 'cet', 'dans', 'pour', 'que', 'quoi', 'ou', 'où', 'vas', 'va',
+  'ouvre', 'lis', 'montre', 'titre', 'lien', 'bouton', 'champ',
+  'من', 'على', 'في', 'إلى', 'الى', 'هذا', 'هذه', 'ذلك', 'تلك', 'لي', 'لو', 'ممكن',
+  'افتح', 'اذهب', 'روح', 'انتقل', 'اقرأ', 'مرر', 'انزل', 'اطلع', 'العنوان', 'الرابط',
+  'الزر', 'الصفحة', 'القسم', 'التالي', 'السابق'
+]);
+
+function hasIntent(text, patterns) {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function tokenizeIntentText(text) {
+  return String(text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\u0600-\u06ff\s]/g, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token && token.length > 1 && !INTENT_STOPWORDS.has(token));
+}
+
+function scoreIntentLabel(label, tokens) {
+  const lower = String(label || '').toLowerCase();
+  if (!lower || !tokens.length) return 0;
+  let score = 0;
+  for (const token of tokens) {
+    if (lower === token) score += 5;
+    else if (lower.startsWith(token) || lower.endsWith(token)) score += 3;
+    else if (lower.includes(token)) score += token.length >= 5 ? 2 : 1;
+  }
+  return score;
+}
+
+function collectIntentCandidates(structure, targetTypes) {
+  const candidates = [];
+  const targets = Array.isArray(targetTypes) && targetTypes.length ? targetTypes : ['link', 'button', 'heading', 'input'];
+  for (const target of targets) {
+    if (target === 'link' && structure && Array.isArray(structure.links)) {
+      structure.links.forEach((item) => candidates.push({ target: 'link', label: item?.label || '' }));
+    }
+    if (target === 'button' && structure && Array.isArray(structure.buttons)) {
+      structure.buttons.forEach((item) => candidates.push({ target: 'button', label: item?.label || '' }));
+    }
+    if (target === 'heading' && structure && Array.isArray(structure.headings)) {
+      structure.headings.forEach((item) => candidates.push({ target: 'heading', label: item?.label || '' }));
+    }
+    if (target === 'input' && structure && Array.isArray(structure.inputs)) {
+      structure.inputs.forEach((item) => candidates.push({ target: 'input', label: item?.label || '' }));
+    }
+  }
+  return candidates;
+}
+
+function chooseIntentTarget(text, structure) {
+  const normalized = String(text || '').toLowerCase();
+  const tokens = tokenizeIntentText(normalized);
+  if (!tokens.length || !structure) return null;
+
+  let targetTypes = ['link', 'button', 'heading', 'input'];
+  if (/\b(button|press|tap|activate|bouton)\b|زر/.test(normalized)) targetTypes = ['button', 'link'];
+  else if (/\b(link|open|visit|launch|website|site|lien|ouvre|visite)\b|رابط|افتح/.test(normalized)) targetTypes = ['link', 'heading', 'button'];
+  else if (/\b(section|heading|part|titre)\b|عنوان|قسم/.test(normalized)) targetTypes = ['heading', 'link'];
+  else if (/\b(field|input|box|search|champ)\b|حقل|بحث/.test(normalized)) targetTypes = ['input', 'button', 'link'];
+
+  const candidates = collectIntentCandidates(structure, targetTypes);
+  let best = null;
+  for (const candidate of candidates) {
+    const score = scoreIntentLabel(candidate.label, tokens);
+    if (!score) continue;
+    if (!best || score > best.score) best = { ...candidate, score };
+  }
+  return best;
+}
+
+function stubPlanner(command, structure, outputLanguage, preferIntentFallback) {
   const text = String(command || '').toLowerCase();
   const steps = [];
   let description = '';
-  const orientation = buildFriendlyOrientation(structure);
+  const orientation = buildFriendlyOrientation(structure, outputLanguage);
+  let matched = false;
 
-  if (text.includes('describe') || text.includes('summarize') || text.includes('summary')) {
+  if (
+    text.includes('describe') ||
+    text.includes('summarize') ||
+    text.includes('summary') ||
+    text.includes('overview') ||
+    text.includes('where am i') ||
+    text.includes('what can i do here') ||
+    /\br[ée]sum[ée]?\b/.test(text) ||
+    /\bd[ée]cri(s|re)\b/.test(text) ||
+    /où suis[- ]?je|ou suis[- ]?je/.test(text) ||
+    /que puis[- ]je faire ici/.test(text) ||
+    /لخص هذه الصفحة|صف هذه الصفحة|أين أنا|اين انا|ماذا يمكنني أن أفعل هنا|ماذا يمكنني ان افعل هنا/.test(text)
+  ) {
     description = orientation;
-  } else if (text.includes('scroll up')) {
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bscroll up\b/, /\bgo up\b/, /\bmove up\b/, /\bback up\b/, /\bup a bit\b/, /\bhigher\b/,
+    /\bmonte\b/, /\bplus haut\b/, /\bfais d[ée]filer vers le haut\b/,
+    /اطلع|اصعد|مرر.*(للأعلى|للاعلى)|فوق/
+  ])) {
     steps.push({ action: 'scroll', direction: 'up' });
-  } else if (text.includes('scroll')) {
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bscroll\b/, /\bgo down\b/, /\bmove down\b/, /\blower\b/, /\bdown a bit\b/, /\bshow me more\b/, /\bkeep going\b/,
+    /\bdescend(s)?\b/, /\bplus bas\b/, /\bfais d[ée]filer vers le bas\b/,
+    /انزل|نز[ّل]|\bمرر.*(للأسفل|للاسفل)\b|تحت/
+  ])) {
     steps.push({ action: 'scroll', direction: 'down' });
-  } else if (text.includes('read title')) {
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bread title\b/, /\bpage title\b/, /\bwhat('?s| is) the title\b/, /\btell me the title\b/,
+    /\blis le titre\b/, /\bquel est le titre\b/,
+    /اقر[أا] العنوان|ما عنوان الصفحة|ما هو عنوان الصفحة/
+  ])) {
     steps.push({ action: 'read_title' });
-  } else if (text.includes('read selection')) {
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bread selection\b/, /\bread selected\b/, /\bwhat did i select\b/,
+    /\blis la s[ée]lection\b/,
+    /اقر[أا] التحديد|ما الذي حددته/
+  ])) {
     steps.push({ action: 'read_selection' });
-  } else if (text.includes('read heading')) {
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bread heading\b/, /\bcurrent heading\b/, /\bwhat heading am i on\b/,
+    /\blis le titre\b/, /\bquel titre\b/, /\bsection actuelle\b/,
+    /اقر[أا] العنوان|ما العنوان الحالي|ما القسم الحالي/
+  ])) {
     steps.push({ action: 'read_heading', n: 1 });
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bwhat('?s| is) focused\b/, /\bwhat am i on\b/, /\bread current\b/, /\bread focused\b/,
+    /\bsur quoi suis[- ]je\b/, /\blis l[' ]?[ée]l[ée]ment courant\b/,
+    /ما العنصر المحدد|على ماذا انا|ما أنا عليه|ما انا عليه/
+  ])) {
+    steps.push({ action: 'read_focused' });
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bnext heading\b/, /\bnext section\b/, /\bnext part\b/, /\bmove forward a section\b/,
+    /\btitre suivant\b/, /\bsection suivante\b/,
+    /العنوان التالي|القسم التالي/
+  ])) {
+    steps.push({ action: 'move_heading', direction: 'next' });
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bprevious heading\b/, /\bprev heading\b/, /\bprevious section\b/, /\bgo back a section\b/, /\blast section\b/,
+    /\btitre pr[ée]c[ée]dent\b/, /\bsection pr[ée]c[ée]dente\b/,
+    /العنوان السابق|القسم السابق/
+  ])) {
+    steps.push({ action: 'move_heading', direction: 'prev' });
+    matched = true;
   } else {
-    // fallback guidance
-    description = 'Try commands like: describe this page, scroll down, read title, read heading.';
+    const target = chooseIntentTarget(text, structure);
+    if (target) {
+      matched = true;
+      if (target.target === 'heading') {
+        steps.push({ action: 'focus_element', target: 'heading', label: target.label });
+      } else if (/\bfocus\b/.test(text)) {
+        steps.push({ action: 'focus_element', target: target.target, label: target.label });
+      } else if (target.target === 'input') {
+        steps.push({ action: 'focus_element', target: 'input', label: target.label });
+      } else {
+        steps.push({ action: 'click_element', target: target.target, label: target.label });
+      }
+    } else if (!preferIntentFallback) {
+      description = outputMessage('try_commands', outputLanguage);
+    }
   }
 
-  return { description, steps };
+  return { description, steps, matched };
 }
 
 function isSummaryCommandText(text) {
@@ -168,6 +464,10 @@ function isSummaryCommandText(text) {
     t.includes("what's on this page") ||
     t.includes('what is on this page') ||
     t.includes("what's this page") ||
+    /r[ée]sum[ée]?.*cette page/.test(t) ||
+    /d[ée]cri(s|re).*cette page/.test(t) ||
+    /c[' ]?est quoi cette page/.test(t) ||
+    /qu[' ]?est[- ]ce que cette page/.test(t) ||
     /ما هذه الصفحه/.test(t) ||
     /ما هذه الصفحة/.test(t) ||
     /ما هو محتوى الصفحة/.test(t) ||
@@ -176,18 +476,28 @@ function isSummaryCommandText(text) {
   );
 }
 
-function buildFriendlyOrientation(structure) {
-  if (!structure) return 'Page summary is unavailable.';
+function buildFriendlyOrientation(structure, outputLanguage) {
+  if (!structure) return outputMessage('summary_unavailable', outputLanguage);
   const counts = structure.counts || {};
-  const title = structure.title ? `Title: ${structure.title}.` : 'No title found.';
-  const basics = `Headings ${counts.headings || 0}, links ${counts.links || 0}, buttons ${counts.buttons || 0}.`;
+  const title = structure.title
+    ? outputMessage('title_value', outputLanguage, { value: structure.title })
+    : outputMessage('no_title', outputLanguage);
+  const basics = outputMessage('counts_value', outputLanguage, {
+    headings: counts.headings || 0,
+    links: counts.links || 0,
+    buttons: counts.buttons || 0
+  });
   const topHeading =
-    structure.headings && structure.headings.length ? `Top heading: ${structure.headings[0].label}.` : '';
-  const excerpt = structure.excerpt ? `Page snippet: ${structure.excerpt.slice(0, 220)}.` : '';
+    structure.headings && structure.headings.length
+      ? outputMessage('top_heading', outputLanguage, { value: structure.headings[0].label })
+      : '';
+  const excerpt = structure.excerpt
+    ? outputMessage('excerpt_value', outputLanguage, { value: structure.excerpt.slice(0, 220) })
+    : '';
   return [title, basics, topHeading, excerpt].filter(Boolean).join(' ');
 }
 
-const summaryCache = { url: null, ts: 0, result: null };
+const summaryCache = { url: null, outputLanguage: 'en', ts: 0, result: null };
 
 async function loadSettings() {
   return new Promise((resolve) => {
@@ -201,7 +511,10 @@ async function loadSettings() {
   });
 }
 
-async function runPlanner(command) {
+async function runPlanner(command, requestedOutputLanguage, preferIntentFallback) {
+  const settings = await loadSettings();
+  const outputLanguage = normalizeOutputLanguage(requestedOutputLanguage || settings.language || 'en-US');
+  await ensureOutputMessages(outputLanguage);
   const structureRes = await sendToActiveTab({ type: 'navable:getStructure' });
   const structure = structureRes && structureRes.structure ? structureRes.structure : null;
   const text = String(command || '').toLowerCase();
@@ -209,7 +522,6 @@ async function runPlanner(command) {
 
   // If the user asks to summarize/summary, prefer backend AI + plan where allowed by settings.
   if (isSummaryRequest) {
-    const settings = await loadSettings();
     const aiEnabled = !!settings.aiEnabled;
     const aiMode = settings.aiMode || 'off';
     const canUseCache =
@@ -217,6 +529,7 @@ async function runPlanner(command) {
       structure &&
       structure.url &&
       summaryCache.url === structure.url &&
+      summaryCache.outputLanguage === outputLanguage &&
       Date.now() - summaryCache.ts < 2 * 60 * 1000;
 
     if (aiEnabled && aiMode !== 'off') {
@@ -227,7 +540,8 @@ async function runPlanner(command) {
             type: 'navable:announce',
             text: cached.description,
             mode: 'assertive',
-            priority: true
+            priority: true,
+            lang: outputLocale(outputLanguage)
           });
         }
         if (aiMode === 'summary_plan' && cached.plan && cached.plan.steps && cached.plan.steps.length) {
@@ -246,7 +560,8 @@ async function runPlanner(command) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             command: command || 'Summarize this page',
-            pageStructure: structure
+            pageStructure: structure,
+            outputLanguage
           })
         });
         if (response.ok) {
@@ -274,7 +589,8 @@ async function runPlanner(command) {
             type: 'navable:announce',
             text: description,
             mode: 'assertive',
-            priority: true
+            priority: true,
+            lang: outputLocale(outputLanguage)
           });
         }
         if (aiMode === 'summary_plan' && aiResult.plan && aiResult.plan.steps && aiResult.plan.steps.length) {
@@ -293,6 +609,7 @@ async function runPlanner(command) {
           suggestions: aiResult.suggestions
         };
         summaryCache.url = structure && structure.url ? structure.url : null;
+        summaryCache.outputLanguage = outputLanguage;
         summaryCache.ts = Date.now();
         summaryCache.result = result;
         return result;
@@ -300,8 +617,14 @@ async function runPlanner(command) {
       // If AI path fails, fall back to local stub planner.
     } else {
       // AI disabled: give a friendly orientation and tell the user how to enable AI.
-      const description = `${buildFriendlyOrientation(structure)} AI summaries are off. Enable AI in options for a richer summary.`;
-      await sendToActiveTab({ type: 'navable:announce', text: description, mode: 'assertive', priority: true });
+      const description = `${buildFriendlyOrientation(structure, outputLanguage)} ${outputMessage('ai_summaries_off', outputLanguage)}`;
+      await sendToActiveTab({
+        type: 'navable:announce',
+        text: description,
+        mode: 'assertive',
+        priority: true,
+        lang: outputLocale(outputLanguage)
+      });
       return {
         ok: true,
         plan: { steps: [] },
@@ -313,14 +636,19 @@ async function runPlanner(command) {
     }
   }
 
-  const plan = stubPlanner(command, structure);
+  const plan = stubPlanner(command, structure, outputLanguage, !!preferIntentFallback);
+
+  if (preferIntentFallback && !plan.matched && !plan.description && (!plan.steps || !plan.steps.length)) {
+    return { ok: false, error: 'Intent not understood', unhandled: true, plan: { steps: [] }, structure };
+  }
 
   if (plan.description) {
     await sendToActiveTab({
       type: 'navable:announce',
       text: plan.description,
       mode: isSummaryRequest ? 'assertive' : 'polite',
-      priority: isSummaryRequest
+      priority: isSummaryRequest,
+      lang: outputLocale(outputLanguage)
     });
   }
   if (plan.steps && plan.steps.length) {
@@ -347,6 +675,125 @@ function normalizeSpokenUrl(query) {
   out = out.replace(/\s*\.\s*/g, '.');
   out = out.replace(/\s*:\s*/g, ':');
   return out.trim();
+}
+
+const KNOWN_SITE_ALIASES = {
+  youtube: 'https://www.youtube.com/',
+  'you tube': 'https://www.youtube.com/',
+  'يوتيوب': 'https://www.youtube.com/',
+  'اليوتيوب': 'https://www.youtube.com/',
+  google: 'https://www.google.com/',
+  'جوجل': 'https://www.google.com/',
+  'غوغل': 'https://www.google.com/',
+  gmail: 'https://mail.google.com/',
+  'google mail': 'https://mail.google.com/',
+  'جي ميل': 'https://mail.google.com/',
+  'جيميل': 'https://mail.google.com/',
+  facebook: 'https://www.facebook.com/',
+  'فيسبوك': 'https://www.facebook.com/',
+  'فيس بوك': 'https://www.facebook.com/',
+  instagram: 'https://www.instagram.com/',
+  'انستغرام': 'https://www.instagram.com/',
+  'انستجرام': 'https://www.instagram.com/',
+  whatsapp: 'https://web.whatsapp.com/',
+  'واتساب': 'https://web.whatsapp.com/',
+  twitter: 'https://x.com/',
+  x: 'https://x.com/',
+  'تويتر': 'https://x.com/',
+  'تيكتوك': 'https://www.tiktok.com/',
+  'تيك توك': 'https://www.tiktok.com/',
+  tiktok: 'https://www.tiktok.com/',
+  linkedin: 'https://www.linkedin.com/',
+  'لينكدان': 'https://www.linkedin.com/',
+  reddit: 'https://www.reddit.com/',
+  'ريديت': 'https://www.reddit.com/',
+  wikipedia: 'https://www.wikipedia.org/',
+  'ويكيبيديا': 'https://www.wikipedia.org/',
+  amazon: 'https://www.amazon.com/',
+  'امازون': 'https://www.amazon.com/',
+  amazonprime: 'https://www.amazon.com/',
+  netflix: 'https://www.netflix.com/',
+  'نتفليكس': 'https://www.netflix.com/',
+  spotify: 'https://open.spotify.com/',
+  'سبوتيفاي': 'https://open.spotify.com/',
+  github: 'https://github.com/',
+  'جيتهاب': 'https://github.com/',
+  'جيت هب': 'https://github.com/',
+  'stack overflow': 'https://stackoverflow.com/',
+  stackoverflow: 'https://stackoverflow.com/',
+  'chat gpt': 'https://chatgpt.com/',
+  chatgpt: 'https://chatgpt.com/',
+  'شات جي بي تي': 'https://chatgpt.com/',
+  'تشات جي بي تي': 'https://chatgpt.com/'
+};
+
+function normalizeNamedSiteQuery(query) {
+  let s = normalizeSpokenUrl(query);
+  if (!s) return '';
+  s = s
+    .replace(/^(the|a|an)\s+/g, '')
+    .replace(/^(site|website|page|app)\s+/g, '')
+    .replace(/^(le|la|les|un|une)\s+/g, '')
+    .replace(/^(site\s+web|site|page|application|appli|onglet)\s+/g, '')
+    .replace(/^(موقع|الموقع|صفحة|الصفحة|تطبيق|التطبيق)\s+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return s;
+}
+
+function resolveNamedSiteUrl(query) {
+  const normalized = normalizeNamedSiteQuery(query);
+  if (!normalized) return null;
+  if (KNOWN_SITE_ALIASES[normalized]) return KNOWN_SITE_ALIASES[normalized];
+
+  const withoutArticle = normalized
+    .replace(/^(the|le|la|les)\s+/g, '')
+    .replace(/^ال/g, '')
+    .trim();
+  if (KNOWN_SITE_ALIASES[withoutArticle]) return KNOWN_SITE_ALIASES[withoutArticle];
+
+  const squeezed = withoutArticle.replace(/\s+/g, '');
+  if (KNOWN_SITE_ALIASES[squeezed]) return KNOWN_SITE_ALIASES[squeezed];
+
+  return null;
+}
+
+function stripDiacritics(value) {
+  const text = String(value || '');
+  if (!text) return '';
+  try {
+    return text.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+  } catch (_e) {
+    return text;
+  }
+}
+
+function guessDirectHostUrl(query) {
+  const normalized = normalizeNamedSiteQuery(query);
+  if (!normalized) return null;
+  if (Array.from(normalized).some((ch) => ch.charCodeAt(0) > 127)) return null;
+
+  const ascii = stripDiacritics(normalized)
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!ascii) return null;
+
+  const tokens = ascii.split(' ').filter(Boolean);
+  if (!tokens.length) return null;
+
+  const joined = tokens.join('');
+  if (!/^[a-z0-9-]+$/.test(joined)) return null;
+  if (joined.length < 2) return `https://${joined}.com/`;
+  return `https://www.${joined}.com/`;
+}
+
+function resolveDirectOpenFallbackUrl(query) {
+  const directGuess = guessDirectHostUrl(query);
+  if (directGuess) return directGuess;
+  return `https://www.google.com/search?btnI=I&q=${encodeURIComponent(`${String(query || '').trim()} official site`)}`;
 }
 
 function tryParseHttpUrl(candidate) {
@@ -392,6 +839,9 @@ function resolveOpenQueryToUrl(query) {
   const direct = tryParseHttpUrl(normalized);
   if (direct) return direct;
 
+  const namedSite = resolveNamedSiteUrl(raw);
+  if (namedSite) return namedSite;
+
   // Domain (with optional path), missing scheme
   if (looksLikeHostWithOptionalPath(normalized)) {
     return tryParseHttpUrl(`https://${normalized}`);
@@ -402,8 +852,8 @@ function resolveOpenQueryToUrl(query) {
     return `https://www.${normalized}.com/`;
   }
 
-  // Fallback to search (works for any phrase)
-  return `https://www.google.com/search?q=${encodeURIComponent(raw)}`;
+  // Open-intent fallback: prefer direct-open behavior over a search-results page.
+  return resolveDirectOpenFallbackUrl(raw);
 }
 
 function friendlyUrlForSpeech(url) {
@@ -417,15 +867,18 @@ function friendlyUrlForSpeech(url) {
   }
 }
 
-async function openSiteInBrowser(query, newTab) {
+async function openSiteInBrowser(query, newTab, requestedOutputLanguage) {
+  const outputLanguage = normalizeOutputLanguage(requestedOutputLanguage);
+  await ensureOutputMessages(outputLanguage);
   const url = resolveOpenQueryToUrl(query);
-  if (!url) return { ok: false, error: 'Missing website name or URL.' };
+  if (!url) return { ok: false, error: outputMessage('missing_url', outputLanguage) };
 
   try {
     await sendToActiveTab({
       type: 'navable:announce',
-      text: `Opening ${friendlyUrlForSpeech(url)}.`,
-      mode: 'assertive'
+      text: outputMessage('opening_value', outputLanguage, { value: friendlyUrlForSpeech(url) }),
+      mode: 'assertive',
+      lang: outputLocale(outputLanguage)
     });
   } catch (_e) {
     // ignore announce failures (e.g., unsupported active tab)
@@ -445,7 +898,7 @@ async function openSiteInBrowser(query, newTab) {
     return { ok: true, url };
   } catch (err) {
     console.warn('[Navable] openSite failed', err);
-    return { ok: false, error: 'Could not open that website.' };
+    return { ok: false, error: outputMessage('open_website_failed', outputLanguage) };
   }
 }
 
@@ -510,7 +963,7 @@ try {
 // Planner + bus bridge
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg && msg.type === 'navable:openSite') {
-    openSiteInBrowser(msg.query || '', msg.newTab).then((res) => {
+    openSiteInBrowser(msg.query || '', msg.newTab, msg.outputLanguage).then((res) => {
       sendResponse(res);
     }).catch((err) => {
       sendResponse({ ok: false, error: String(err || 'open site failed') });
@@ -518,7 +971,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     return true;
   }
   if (msg && msg.type === 'planner:run') {
-    runPlanner(msg.command || '').then((res) => {
+    runPlanner(msg.command || '', msg.outputLanguage, msg.preferIntentFallback).then((res) => {
       sendResponse(res);
     }).catch((err) => {
       sendResponse({ ok: false, error: String(err || 'planner failed') });
@@ -527,7 +980,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
   if (msg && msg.type === 'bus:request') {
     if (msg.kind === 'planner:run') {
-      runPlanner(msg.payload?.command || '').then((res) => sendResponse(res)).catch((err) => {
+      runPlanner(msg.payload?.command || '', msg.payload?.outputLanguage, msg.payload?.preferIntentFallback).then((res) => sendResponse(res)).catch((err) => {
         sendResponse({ ok: false, error: String(err || 'planner failed') });
       });
       return true;

--- a/dist/src/common/announce.js
+++ b/dist/src/common/announce.js
@@ -202,7 +202,14 @@
     return panel;
   }
 
-  function showPriorityOutput(text) {
+  function applyLanguageAttributes(node, opts) {
+    if (!node) return;
+    const lang = opts && opts.lang ? String(opts.lang).trim() : '';
+    if (lang) node.setAttribute('lang', lang);
+    else node.removeAttribute('lang');
+  }
+
+  function showPriorityOutput(text, opts) {
     const panel = ensurePriorityPanel();
     if (!panel) return;
     const textarea = document.getElementById('navable-output-text');
@@ -224,6 +231,8 @@
     panel.style.display = 'block';
     emitOutputOpen(true);
     textarea.value = message;
+    applyLanguageAttributes(panel, opts);
+    applyLanguageAttributes(textarea, opts);
 
     // Put the screen reader/keyboard cursor directly on the output text and select it.
     setTimeout(() => {
@@ -239,6 +248,7 @@
   function setAnnounceText(region, mode, text, opts) {
     const m = mode === 'assertive' ? 'assertive' : 'polite';
     const shouldFocus = !!(opts && opts.focus === true);
+    applyLanguageAttributes(region, opts);
 
     // A clear-then-set with small delays is more reliably announced by VoiceOver and NVDA.
     if (timersByMode[m]) {
@@ -270,8 +280,8 @@
       const region = ensureLiveRegion(mode);
       setAnnounceText(region, mode, text, opts);
     },
-    output(text) {
-      showPriorityOutput(text);
+    output(text, opts) {
+      showPriorityOutput(text, opts);
     }
   };
 })();

--- a/dist/src/common/i18n.js
+++ b/dist/src/common/i18n.js
@@ -1,0 +1,380 @@
+(function () {
+  if (typeof window === 'undefined' || window.NavableI18n) return;
+
+  var DEFAULT_LANGUAGE = 'en';
+  var DEFAULT_TRANSLATE_URL = 'http://localhost:3000/api/translate-messages';
+  var LOCALES = {
+    en: 'en-US',
+    fr: 'fr-FR',
+    ar: 'ar-SA'
+  };
+
+  var LANGUAGE_NAMES = {
+    english: 'en',
+    anglais: 'en',
+    eng: 'en',
+    french: 'fr',
+    francais: 'fr',
+    français: 'fr',
+    arabe: 'ar',
+    arabic: 'ar',
+    arabee: 'ar',
+    العربية: 'ar',
+    الانجليزية: 'en',
+    الإنجليزية: 'en',
+    الفرنسية: 'fr'
+  };
+
+  var MESSAGES = {
+    en: {
+      navable_ready: 'Navable is ready. Say "help" to hear example commands.',
+      navable_test_announcement: 'Navable: test announcement (fallback hotkey).',
+      generic_announcement: 'Navable: announcement.',
+      help_examples:
+        'Try: summarize this page, scroll down, read title, next heading, open first link, activate focused, read selection. Press Alt+Shift+M to toggle listening.',
+      listening_help: 'Listening. Say "help" to hear example commands.',
+      stopped_listening: 'Stopped listening. Press Alt+Shift+M to start again.',
+      unknown_command: 'I did not catch that. Say "help" to hear example commands.',
+      speech_not_available: 'Speech recognition not available.',
+      speech_not_allowed: 'Speech recognition is not allowed in this browser.',
+      speech_network_issue: 'Speech recognition is unavailable due to a network issue.',
+      speech_problem_retry: 'Speech recognition had a problem. Please try again.',
+      microphone_busy_retry: 'Microphone is busy in another tab or app. Retrying...',
+      scrolled_down: 'Scrolled down.',
+      scrolled_up: 'Scrolled up.',
+      scrolled_top: 'Scrolled to top.',
+      scrolled_bottom: 'Scrolled to bottom.',
+      title_value: 'Title: {value}',
+      value_not_found: 'not found',
+      selection_value: 'Selection: {value}',
+      no_selection: 'No selection.',
+      no_focused_text: 'No focused element text.',
+      no_focused_element: 'No focused element.',
+      not_found_heading: 'I did not find that heading.',
+      not_found_link: 'I did not find that link.',
+      not_found_button: 'I did not find that button.',
+      not_found_generic: 'I did not find a {target}.',
+      heading_value: 'Heading: {value}',
+      unnamed: 'unnamed',
+      opening_value: 'Opening {value}',
+      focused_value: 'Focused {value}',
+      activated_value: 'Activated {value}',
+      target_link: 'link',
+      target_button: 'button',
+      target_heading: 'heading',
+      target_input: 'input',
+      target_element: 'element',
+      summarizing_wait: 'Summarizing this page... please wait.',
+      summarize_unavailable_page: 'Sorry, summarization is unavailable on this page.',
+      summarize_failed: 'Sorry, I could not summarize this page.',
+      summarize_request_failed: 'Sorry, the summary request failed. Please try again.',
+      tell_website_to_open: 'Tell me which website to open.',
+      open_site_unavailable: 'Opening a website is unavailable.',
+      open_site_failed: 'Could not open that site.',
+      wait_for_user_input: 'Please provide input, then tell me to continue.',
+      newtab_try_open: 'I did not catch that. Try: "Open YouTube".',
+      newtab_help_examples: 'Try: "Open YouTube", "Open example dot com", "Search for weather".',
+      newtab_listening: 'Listening... Say "Open YouTube".',
+      voice_unavailable_browser: 'Voice input is not available in this browser.',
+      mic_access_blocked: 'Microphone access is blocked. Allow microphone for this extension to use voice.',
+      mic_busy: 'Microphone is busy. Close other apps or tabs using the mic, then try again.',
+      opening_site: 'Opening {value}...',
+      missing_url: 'Missing website name or URL.'
+    },
+    fr: {
+      navable_ready: 'Navable est pret. Dites "aide" pour entendre des exemples de commandes.',
+      navable_test_announcement: 'Navable : annonce de test (raccourci de secours).',
+      generic_announcement: 'Navable : annonce.',
+      help_examples:
+        'Essayez : resume cette page, fais defiler vers le bas, lis le titre, titre suivant, ouvre le premier lien, active l element cible, lis la selection. Appuyez sur Alt+Shift+M pour activer ou arreter l ecoute.',
+      listening_help: 'J ecoute. Dites "aide" pour entendre des exemples de commandes.',
+      stopped_listening: 'Ecoute arretee. Appuyez sur Alt+Shift+M pour recommencer.',
+      unknown_command: 'Je n ai pas compris. Dites "aide" pour entendre des exemples de commandes.',
+      speech_not_available: 'La reconnaissance vocale n est pas disponible.',
+      speech_not_allowed: 'La reconnaissance vocale n est pas autorisee dans ce navigateur.',
+      speech_network_issue: 'La reconnaissance vocale est indisponible a cause d un probleme reseau.',
+      speech_problem_retry: 'La reconnaissance vocale a rencontre un probleme. Reessayez.',
+      microphone_busy_retry: 'Le microphone est utilise dans un autre onglet ou une autre application. Nouvelle tentative...',
+      scrolled_down: 'Defilement vers le bas.',
+      scrolled_up: 'Defilement vers le haut.',
+      scrolled_top: 'Retour en haut de la page.',
+      scrolled_bottom: 'Aller en bas de la page.',
+      title_value: 'Titre : {value}',
+      value_not_found: 'introuvable',
+      selection_value: 'Selection : {value}',
+      no_selection: 'Aucune selection.',
+      no_focused_text: 'Aucun texte sur l element cible.',
+      no_focused_element: 'Aucun element cible.',
+      not_found_heading: 'Je n ai pas trouve ce titre.',
+      not_found_link: 'Je n ai pas trouve ce lien.',
+      not_found_button: 'Je n ai pas trouve ce bouton.',
+      not_found_generic: 'Je n ai pas trouve {target}.',
+      heading_value: 'Titre : {value}',
+      unnamed: 'sans nom',
+      opening_value: 'Ouverture de {value}',
+      focused_value: 'Focus sur {value}',
+      activated_value: 'Activation de {value}',
+      target_link: 'le lien',
+      target_button: 'le bouton',
+      target_heading: 'le titre',
+      target_input: 'le champ',
+      target_element: 'l element',
+      summarizing_wait: 'Je resume cette page... veuillez patienter.',
+      summarize_unavailable_page: 'Desole, le resume n est pas disponible sur cette page.',
+      summarize_failed: 'Desole, je n ai pas pu resumer cette page.',
+      summarize_request_failed: 'Desole, la demande de resume a echoue. Reessayez.',
+      tell_website_to_open: 'Dites-moi quel site ouvrir.',
+      open_site_unavailable: 'L ouverture d un site web n est pas disponible.',
+      open_site_failed: 'Impossible d ouvrir ce site.',
+      wait_for_user_input: 'Veuillez fournir une saisie, puis dites-moi de continuer.',
+      newtab_try_open: 'Je n ai pas compris. Essayez : "Ouvre YouTube".',
+      newtab_help_examples: 'Essayez : "Ouvre YouTube", "Ouvre example point com", "Recherche la meteo".',
+      newtab_listening: 'J ecoute... Dites "Ouvre YouTube".',
+      voice_unavailable_browser: 'La saisie vocale n est pas disponible dans ce navigateur.',
+      mic_access_blocked: 'L acces au microphone est bloque. Autorisez le microphone pour cette extension.',
+      mic_busy: 'Le microphone est occupe. Fermez les autres applications ou onglets qui l utilisent, puis reessayez.',
+      opening_site: 'Ouverture de {value}...',
+      missing_url: 'Nom du site ou URL manquant.'
+    },
+    ar: {
+      navable_ready: 'نافابل جاهز. قل "مساعدة" لسماع أمثلة للأوامر.',
+      navable_test_announcement: 'نافابل: إعلان تجريبي (اختصار احتياطي).',
+      generic_announcement: 'نافابل: إعلان.',
+      help_examples:
+        'جرّب: لخّص هذه الصفحة، مرر إلى الأسفل، اقرأ العنوان، العنوان التالي، افتح أول رابط، فعّل العنصر المحدد، اقرأ التحديد. اضغط Alt+Shift+M لتبديل الاستماع.',
+      listening_help: 'أستمع الآن. قل "مساعدة" لسماع أمثلة للأوامر.',
+      stopped_listening: 'تم إيقاف الاستماع. اضغط Alt+Shift+M للبدء من جديد.',
+      unknown_command: 'لم أفهم ذلك. قل "مساعدة" لسماع أمثلة للأوامر.',
+      speech_not_available: 'التعرّف على الكلام غير متاح.',
+      speech_not_allowed: 'التعرّف على الكلام غير مسموح به في هذا المتصفح.',
+      speech_network_issue: 'التعرّف على الكلام غير متاح بسبب مشكلة في الشبكة.',
+      speech_problem_retry: 'حدثت مشكلة في التعرّف على الكلام. حاول مرة أخرى.',
+      microphone_busy_retry: 'الميكروفون مستخدم في تبويب أو تطبيق آخر. سأحاول مرة أخرى...',
+      scrolled_down: 'تم التمرير إلى الأسفل.',
+      scrolled_up: 'تم التمرير إلى الأعلى.',
+      scrolled_top: 'تم الانتقال إلى أعلى الصفحة.',
+      scrolled_bottom: 'تم الانتقال إلى أسفل الصفحة.',
+      title_value: 'العنوان: {value}',
+      value_not_found: 'غير موجود',
+      selection_value: 'التحديد: {value}',
+      no_selection: 'لا يوجد تحديد.',
+      no_focused_text: 'لا يوجد نص للعنصر المحدد.',
+      no_focused_element: 'لا يوجد عنصر محدد.',
+      not_found_heading: 'لم أجد هذا العنوان.',
+      not_found_link: 'لم أجد هذا الرابط.',
+      not_found_button: 'لم أجد هذا الزر.',
+      not_found_generic: 'لم أجد {target}.',
+      heading_value: 'العنوان: {value}',
+      unnamed: 'بدون اسم',
+      opening_value: 'جارٍ فتح {value}',
+      focused_value: 'تم التركيز على {value}',
+      activated_value: 'تم تفعيل {value}',
+      target_link: 'الرابط',
+      target_button: 'الزر',
+      target_heading: 'العنوان',
+      target_input: 'حقل الإدخال',
+      target_element: 'العنصر',
+      summarizing_wait: 'أقوم بتلخيص هذه الصفحة... يرجى الانتظار.',
+      summarize_unavailable_page: 'عذراً، التلخيص غير متاح في هذه الصفحة.',
+      summarize_failed: 'عذراً، لم أتمكن من تلخيص هذه الصفحة.',
+      summarize_request_failed: 'عذراً، فشل طلب التلخيص. حاول مرة أخرى.',
+      tell_website_to_open: 'أخبرني بأي موقع تريد فتحه.',
+      open_site_unavailable: 'فتح موقع ويب غير متاح.',
+      open_site_failed: 'تعذر فتح هذا الموقع.',
+      wait_for_user_input: 'يرجى إدخال البيانات ثم أخبرني أن أتابع.',
+      newtab_try_open: 'لم أفهم ذلك. جرّب: "افتح يوتيوب".',
+      newtab_help_examples: 'جرّب: "افتح يوتيوب"، "افتح example dot com"، "ابحث عن الطقس".',
+      newtab_listening: 'أستمع الآن... قل "افتح يوتيوب".',
+      voice_unavailable_browser: 'الإدخال الصوتي غير متاح في هذا المتصفح.',
+      mic_access_blocked: 'الوصول إلى الميكروفون محظور. اسمح للميكروفون لهذه الإضافة لاستخدام الصوت.',
+      mic_busy: 'الميكروفون مشغول. أغلق التطبيقات أو التبويبات الأخرى التي تستخدمه ثم حاول مرة أخرى.',
+      opening_site: 'جارٍ فتح {value}...',
+      missing_url: 'اسم الموقع أو الرابط مفقود.'
+    }
+  };
+
+  var pendingLanguageLoads = {};
+
+  function getFetchImpl() {
+    return window.fetch;
+  }
+
+  function canonicalizeLocale(lang) {
+    var raw = String(lang || '').trim().replace(/_/g, '-');
+    if (!raw) return '';
+    try {
+      if (window.Intl && typeof window.Intl.Locale === 'function') {
+        return new window.Intl.Locale(raw).baseName;
+      }
+    } catch (_err) {
+      // fall through
+    }
+
+    var parts = raw.split('-').filter(Boolean);
+    if (!parts.length) return '';
+    parts[0] = parts[0].toLowerCase();
+    for (var i = 1; i < parts.length; i++) {
+      if (parts[i].length === 2) parts[i] = parts[i].toUpperCase();
+      else if (parts[i].length === 4) parts[i] = parts[i].charAt(0).toUpperCase() + parts[i].slice(1).toLowerCase();
+      else parts[i] = parts[i].toLowerCase();
+    }
+    return parts.join('-');
+  }
+
+  function normalizeLanguage(lang) {
+    var raw = String(lang || '').trim().toLowerCase();
+    if (!raw) return DEFAULT_LANGUAGE;
+    if (LANGUAGE_NAMES[raw]) return LANGUAGE_NAMES[raw];
+
+    var canonical = canonicalizeLocale(raw);
+    if (canonical) {
+      var primary = canonical.split('-')[0].toLowerCase();
+      if (LANGUAGE_NAMES[primary]) return LANGUAGE_NAMES[primary];
+      return primary || DEFAULT_LANGUAGE;
+    }
+
+    var parts = raw.split(/[-_]/);
+    if (parts[0] && LANGUAGE_NAMES[parts[0]]) return LANGUAGE_NAMES[parts[0]];
+    return parts[0] || DEFAULT_LANGUAGE;
+  }
+
+  function localeForLanguage(lang) {
+    var normalized = normalizeLanguage(lang);
+    if (LOCALES[normalized]) return LOCALES[normalized];
+    var canonical = canonicalizeLocale(lang);
+    if (canonical) return canonical;
+    return normalized || LOCALES[DEFAULT_LANGUAGE];
+  }
+
+  function interpolate(template, params) {
+    var text = String(template || '');
+    var values = params || {};
+    return text.replace(/\{(\w+)\}/g, function (_m, key) {
+      return Object.prototype.hasOwnProperty.call(values, key) ? String(values[key]) : '';
+    });
+  }
+
+  function sanitizeMessages(candidate, fallbackMessages) {
+    var safe = {};
+    var fallback = fallbackMessages || {};
+    Object.keys(fallback).forEach(function (key) {
+      var value = candidate && Object.prototype.hasOwnProperty.call(candidate, key) ? candidate[key] : null;
+      safe[key] = typeof value === 'string' && value.trim() ? value : fallback[key];
+    });
+    return safe;
+  }
+
+  function t(key, lang, params) {
+    var normalized = normalizeLanguage(lang);
+    var messages = MESSAGES[normalized] || MESSAGES[DEFAULT_LANGUAGE];
+    var fallbackMessages = MESSAGES[DEFAULT_LANGUAGE];
+    var template = messages[key];
+    if (template == null) template = fallbackMessages[key];
+    if (template == null) return key;
+    return interpolate(template, params);
+  }
+
+  function ensureLanguage(lang) {
+    var normalized = normalizeLanguage(lang);
+    if (!normalized || normalized === DEFAULT_LANGUAGE || MESSAGES[normalized]) {
+      return Promise.resolve(MESSAGES[normalized] || MESSAGES[DEFAULT_LANGUAGE]);
+    }
+    if (pendingLanguageLoads[normalized]) return pendingLanguageLoads[normalized];
+
+    var fetchImpl = getFetchImpl();
+    if (typeof fetchImpl !== 'function') {
+      return Promise.resolve(MESSAGES[DEFAULT_LANGUAGE]);
+    }
+
+    pendingLanguageLoads[normalized] = fetchImpl(DEFAULT_TRANSLATE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        language: normalized,
+        messages: MESSAGES[DEFAULT_LANGUAGE]
+      })
+    }).then(function (response) {
+      if (!response || !response.ok) throw new Error('Language pack request failed');
+      return response.json();
+    }).then(function (payload) {
+      var translated = sanitizeMessages(payload && payload.messages ? payload.messages : null, MESSAGES[DEFAULT_LANGUAGE]);
+      MESSAGES[normalized] = translated;
+      return translated;
+    }).catch(function () {
+      return MESSAGES[DEFAULT_LANGUAGE];
+    }).finally(function () {
+      delete pendingLanguageLoads[normalized];
+    });
+
+    return pendingLanguageLoads[normalized];
+  }
+
+  function countMatches(text, pattern) {
+    var matches = String(text || '').match(pattern);
+    return matches ? matches.length : 0;
+  }
+
+  function detectLanguage(text, fallbackLanguage) {
+    var raw = String(text || '').trim();
+    if (!raw) return normalizeLanguage(fallbackLanguage);
+    if (/[\u0600-\u06FF]/.test(raw)) return 'ar';
+
+    var lower = raw.toLowerCase();
+    var frScore = 0;
+    var enScore = 0;
+
+    if (/[àâçéèêëîïôûùüÿœæ]/i.test(raw)) frScore += 3;
+    frScore += countMatches(lower, /\b(bonjour|salut|merci|ouvre|ouvrir|recherche|resume|résume|résumé|decris|décris|titre|page|lien|bouton|suivant|precedent|précédent|aide|ecoute|écoute)\b/g);
+    enScore += countMatches(lower, /\b(open|search|scroll|summary|summarize|describe|title|button|link|page|help|listen|stop|start|next|previous|focus|activate)\b/g);
+
+    if (frScore > enScore && frScore > 0) return 'fr';
+    if (enScore > frScore && enScore > 0) return 'en';
+
+    return normalizeLanguage(fallbackLanguage);
+  }
+
+  function resolveNamedLanguage(name) {
+    var normalized = String(name || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[.,!?]/g, '');
+    return LANGUAGE_NAMES[normalized] || null;
+  }
+
+  function extractExplicitOutputLanguage(text) {
+    var raw = String(text || '').trim();
+    if (!raw) return null;
+    var lower = raw.toLowerCase();
+
+    var englishMatch = lower.match(/\b(?:answer|respond|reply|speak|say|summarize|summarise|describe)\b[\s\S]{0,24}?\b(?:in)\s+(english|french|arabic)\b/);
+    if (englishMatch && englishMatch[1]) return resolveNamedLanguage(englishMatch[1]);
+
+    var frenchMatch = lower.match(/\b(?:reponds|réponds|parle|dis|resume|résume|decris|décris)\b[\s\S]{0,24}?\ben\s+(anglais|francais|français|arabe)\b/);
+    if (frenchMatch && frenchMatch[1]) return resolveNamedLanguage(frenchMatch[1]);
+
+    if (/بالانجليزية|بالإنجليزية/.test(raw)) return 'en';
+    if (/بالفرنسية/.test(raw)) return 'fr';
+    if (/بالعربية/.test(raw)) return 'ar';
+
+    return null;
+  }
+
+  function resolveOutputLanguage(options) {
+    var opts = options || {};
+    var transcript = opts.transcript || '';
+    var explicit = extractExplicitOutputLanguage(transcript);
+    if (explicit) return normalizeLanguage(explicit);
+    return detectLanguage(transcript, opts.fallbackLanguage || DEFAULT_LANGUAGE);
+  }
+
+  window.NavableI18n = {
+    messages: MESSAGES,
+    normalizeLanguage: normalizeLanguage,
+    localeForLanguage: localeForLanguage,
+    detectLanguage: detectLanguage,
+    extractExplicitOutputLanguage: extractExplicitOutputLanguage,
+    resolveOutputLanguage: resolveOutputLanguage,
+    ensureLanguage: ensureLanguage,
+    t: t
+  };
+})();

--- a/dist/src/common/speech.js
+++ b/dist/src/common/speech.js
@@ -1,27 +1,115 @@
-// Lightweight Web Speech API wrapper for Navable
-// Exposes window.NavableSpeech with:
-// - supportsRecognition(): boolean
-// - createRecognizer(opts): { start(), stop(), on(event, handler) }
-// - speak(text): Promise<void>
+// Hybrid speech layer for Navable:
+// - primary: backend multilingual transcription via MediaRecorder + /api/transcribe
+// - fallback: browser Web Speech API when backend capture/transcription is unavailable
 (function () {
   if (typeof window === 'undefined' || window.NavableSpeech) return;
 
-  var NativeRecognition =
-    window.SpeechRecognition ||
-    window.webkitSpeechRecognition ||
-    window.mozSpeechRecognition ||
-    window.msSpeechRecognition;
+  var DEFAULT_TRANSCRIBE_URL = 'http://localhost:3000/api/transcribe';
+  var DEFAULT_HEALTH_URL = 'http://localhost:3000/health';
 
-  function supportsRecognition() {
-    return !!NativeRecognition;
+  function getSpeechEnv() {
+    return window.__NavableSpeechEnv || {};
   }
 
-  function createRecognizer(options) {
+  function getNativeRecognitionCtor() {
+    var env = getSpeechEnv();
+    return (
+      env.SpeechRecognition ||
+      window.SpeechRecognition ||
+      window.webkitSpeechRecognition ||
+      window.mozSpeechRecognition ||
+      window.msSpeechRecognition
+    );
+  }
+
+  function getAudioContextCtor() {
+    var env = getSpeechEnv();
+    return env.AudioContext || window.AudioContext || window.webkitAudioContext;
+  }
+
+  function getMediaRecorderCtor() {
+    var env = getSpeechEnv();
+    return env.MediaRecorder || window.MediaRecorder;
+  }
+
+  function getMediaDevices() {
+    var env = getSpeechEnv();
+    return env.mediaDevices || (window.navigator && window.navigator.mediaDevices);
+  }
+
+  function getFetchImpl() {
+    var env = getSpeechEnv();
+    return env.fetch || window.fetch;
+  }
+
+  function supportsNativeRecognition() {
+    return !!getNativeRecognitionCtor();
+  }
+
+  function supportsBackendRecognition() {
+    var MediaRecorderCtor = getMediaRecorderCtor();
+    var AudioContextCtor = getAudioContextCtor();
+    var mediaDevices = getMediaDevices();
+    var fetchImpl = getFetchImpl();
+    return !!(
+      fetchImpl &&
+      MediaRecorderCtor &&
+      AudioContextCtor &&
+      mediaDevices &&
+      typeof mediaDevices.getUserMedia === 'function'
+    );
+  }
+
+  function supportsRecognition() {
+    return supportsBackendRecognition() || supportsNativeRecognition();
+  }
+
+  function createEmitter(extraEvents) {
+    var listeners = {
+      result: [],
+      error: [],
+      start: [],
+      end: []
+    };
+
+    (extraEvents || []).forEach(function (name) {
+      listeners[name] = [];
+    });
+
+    function emit(type, payload) {
+      var list = listeners[type];
+      if (!list || !list.length) return;
+      list.forEach(function (fn) {
+        try {
+          fn(payload);
+        } catch (_err) {
+          // swallow handler errors
+        }
+      });
+    }
+
+    function on(type, handler) {
+      if (!listeners[type] || typeof handler !== 'function') return api;
+      listeners[type].push(handler);
+      return api;
+    }
+
+    var api = {
+      emit: emit,
+      on: on
+    };
+
+    return api;
+  }
+
+  function createNativeRecognizer(options) {
     options = options || {};
+    var NativeRecognition = getNativeRecognitionCtor();
     if (!NativeRecognition) {
       throw new Error('Speech recognition not supported');
     }
 
+    var emitter = createEmitter();
     var recognizer = new NativeRecognition();
     recognizer.lang = options.lang || 'en-US';
     recognizer.interimResults = !!options.interimResults;
@@ -33,12 +121,6 @@
     var isStarting = false;
     var isStarted = false;
     var restartTimer = null;
-    var listeners = {
-      result: [],
-      error: [],
-      start: [],
-      end: []
-    };
 
     function clearRestartTimer() {
       if (!restartTimer) return;
@@ -52,22 +134,9 @@
 
     function emitStartError(err) {
       var name = err && err.name ? String(err.name) : '';
-      // Treat "already started" as a no-op to keep start() idempotent.
       if (name === 'InvalidStateError') return;
       var code = (name === 'NotAllowedError' || name === 'SecurityError') ? 'not-allowed' : 'start-failed';
-      emit('error', { error: code, message: String(err || ''), raw: err });
-    }
-
-    function emit(type, payload) {
-      var list = listeners[type];
-      if (!list || !list.length) return;
-      list.forEach(function (fn) {
-        try {
-          fn(payload);
-        } catch (_err) {
-          // swallow handler errors
-        }
-      });
+      emitter.emit('error', { error: code, message: String(err || ''), raw: err });
     }
 
     recognizer.onresult = function (event) {
@@ -82,29 +151,26 @@
       }
       transcript = String(transcript || '').trim();
       if (!transcript) return;
-      if (!isFinal && options.onlyFinal !== false && !options.interimResults) {
-        // Skip interim results when onlyFinal is desired.
-        return;
-      }
-      emit('result', {
+      if (!isFinal && options.onlyFinal !== false && !options.interimResults) return;
+      emitter.emit('result', {
         transcript: transcript,
         isFinal: isFinal,
-        raw: event
+        raw: event,
+        provider: 'native'
       });
     };
 
     recognizer.onerror = function (event) {
       var code = event && event.error ? String(event.error) : 'unknown';
-      // On hard errors, stop auto-restart to avoid tight loops.
       if (code === 'not-allowed' || code === 'service-not-allowed' || code === 'network') {
         shouldRestart = false;
       }
-      // Ensure manual re-starts aren't blocked by stale state.
       isStarting = false;
-      emit('error', {
+      emitter.emit('error', {
         error: code,
         message: event && event.message ? String(event.message) : '',
-        raw: event
+        raw: event,
+        provider: 'native'
       });
     };
 
@@ -112,23 +178,24 @@
       clearRestartTimer();
       isStarting = false;
       isStarted = true;
-      emit('start');
+      emitter.emit('start', { provider: 'native' });
     };
 
     recognizer.onend = function (event) {
       clearRestartTimer();
       isStarting = false;
       isStarted = false;
-      emit('end', { raw: event });
+      emitter.emit('end', { raw: event, provider: 'native' });
       if (autoRestart && shouldRestart) {
-        // Guard against external start() calls while we're between restarts.
         isStarting = true;
         restartTimer = setTimeout(function () {
-          if (!(autoRestart && shouldRestart)) { isStarting = false; return; }
+          if (!(autoRestart && shouldRestart)) {
+            isStarting = false;
+            return;
+          }
           try {
             recognizer.start();
           } catch (_err) {
-            // restart failed; give up
             isStarting = false;
             shouldRestart = false;
           }
@@ -136,7 +203,7 @@
       }
     };
 
-    var api = {
+    return {
       start: function () {
         shouldRestart = autoRestart;
         if (isStarted || isStarting) return;
@@ -149,29 +216,532 @@
           emitStartError(err);
         }
       },
-      stop: function () {
+      stop: function (opts) {
+        opts = opts || {};
         shouldRestart = false;
         clearRestartTimer();
         isStarting = false;
+        if (opts.silent) {
+          recognizer.onend = function () {
+            clearRestartTimer();
+            isStarting = false;
+            isStarted = false;
+          };
+        }
         try {
           recognizer.stop();
         } catch (err) {
-          emit('error', { error: 'stop-failed', message: String(err || ''), raw: err });
+          emitter.emit('error', { error: 'stop-failed', message: String(err || ''), raw: err, provider: 'native' });
         }
       },
-      on: function (eventName, handler) {
-        if (!listeners[eventName]) return api;
-        if (typeof handler === 'function') {
-          listeners[eventName].push(handler);
-        }
-        return api;
-      }
+      on: emitter.on
     };
-
-    return api;
   }
 
-  function speak(text) {
+  function pickRecorderMimeType() {
+    var MediaRecorderCtor = getMediaRecorderCtor();
+    if (!MediaRecorderCtor || typeof MediaRecorderCtor.isTypeSupported !== 'function') {
+      return '';
+    }
+    var candidates = [
+      'audio/webm;codecs=opus',
+      'audio/webm',
+      'audio/ogg;codecs=opus',
+      'audio/mp4'
+    ];
+    for (var i = 0; i < candidates.length; i++) {
+      if (MediaRecorderCtor.isTypeSupported(candidates[i])) return candidates[i];
+    }
+    return '';
+  }
+
+  function blobToBase64(blob) {
+    return new Promise(function (resolve, reject) {
+      try {
+        var reader = new window.FileReader();
+        reader.onloadend = function () {
+          var result = String(reader.result || '');
+          var commaIndex = result.indexOf(',');
+          resolve(commaIndex >= 0 ? result.slice(commaIndex + 1) : result);
+        };
+        reader.onerror = function () {
+          reject(reader.error || new Error('Failed to read audio blob'));
+        };
+        reader.readAsDataURL(blob);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  function fetchWithTimeout(url, init, timeoutMs) {
+    return new Promise(function (resolve, reject) {
+      var done = false;
+      var timer = setTimeout(function () {
+        if (done) return;
+        done = true;
+        reject(new Error('Timed out'));
+      }, Math.max(0, timeoutMs || 0));
+
+      getFetchImpl()(url, init).then(function (response) {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        resolve(response);
+      }).catch(function (err) {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+  }
+
+  function createBackendRecognizer(options) {
+    options = options || {};
+    var emitter = createEmitter(['unavailable']);
+    var transcribeUrl = options.transcribeUrl || DEFAULT_TRANSCRIBE_URL;
+    var healthUrl = options.healthUrl || DEFAULT_HEALTH_URL;
+    var levelThreshold = typeof options.levelThreshold === 'number' ? options.levelThreshold : 0.018;
+    var silenceMs = typeof options.silenceMs === 'number' ? options.silenceMs : 1100;
+    var minSpeechMs = typeof options.minSpeechMs === 'number' ? options.minSpeechMs : 600;
+    var maxRecordingMs = typeof options.maxRecordingMs === 'number' ? options.maxRecordingMs : 12000;
+    var checkIntervalMs = typeof options.checkIntervalMs === 'number' ? options.checkIntervalMs : 100;
+    var AudioContextCtor = getAudioContextCtor();
+    var MediaRecorderCtor = getMediaRecorderCtor();
+
+    var mediaStream = null;
+    var audioContext = null;
+    var sourceNode = null;
+    var analyserNode = null;
+    var levelData = null;
+    var monitorTimer = null;
+    var recorder = null;
+    var recordedChunks = [];
+    var started = false;
+    var starting = false;
+    var shouldRun = false;
+    var healthChecked = false;
+    var healthAvailable = false;
+    var recordingStartedAt = 0;
+    var lastSpeechAt = 0;
+    var sawSpeech = false;
+    var pendingTranscription = false;
+    var discardPendingBlob = false;
+    var suppressEnd = false;
+
+    function cleanupNodes() {
+      if (monitorTimer) {
+        try {
+          clearInterval(monitorTimer);
+        } catch (_err) {
+          // ignore
+        }
+        monitorTimer = null;
+      }
+      try {
+        if (sourceNode) sourceNode.disconnect();
+      } catch (_err2) {
+        // ignore
+      }
+      try {
+        if (analyserNode) analyserNode.disconnect();
+      } catch (_err3) {
+        // ignore
+      }
+      sourceNode = null;
+      analyserNode = null;
+      levelData = null;
+
+      if (audioContext) {
+        try {
+          audioContext.close();
+        } catch (_err4) {
+          // ignore
+        }
+      }
+      audioContext = null;
+
+      if (mediaStream) {
+        try {
+          mediaStream.getTracks().forEach(function (track) {
+            try {
+              track.stop();
+            } catch (_err5) {
+              // ignore
+            }
+          });
+        } catch (_err6) {
+          // ignore
+        }
+      }
+      mediaStream = null;
+    }
+
+    function finalizeStop() {
+      cleanupNodes();
+      started = false;
+      starting = false;
+      recorder = null;
+      recordedChunks = [];
+      recordingStartedAt = 0;
+      lastSpeechAt = 0;
+      sawSpeech = false;
+      discardPendingBlob = false;
+      pendingTranscription = false;
+      if (suppressEnd) {
+        suppressEnd = false;
+        return;
+      }
+      emitter.emit('end', { provider: 'backend' });
+    }
+
+    function emitUnavailable(message, errorCode) {
+      emitter.emit('unavailable', {
+        error: errorCode || 'backend-unavailable',
+        message: String(message || ''),
+        provider: 'backend'
+      });
+    }
+
+    async function probeBackend() {
+      if (healthChecked) return healthAvailable;
+      healthChecked = true;
+      try {
+        var response = await fetchWithTimeout(healthUrl, { method: 'GET' }, 1500);
+        healthAvailable = !!(response && response.ok);
+      } catch (_err) {
+        healthAvailable = false;
+      }
+      return healthAvailable;
+    }
+
+    function getAudioLevel() {
+      if (!analyserNode || !levelData) return 0;
+      analyserNode.getByteTimeDomainData(levelData);
+      var sum = 0;
+      for (var i = 0; i < levelData.length; i++) {
+        var centered = (levelData[i] - 128) / 128;
+        sum += centered * centered;
+      }
+      return Math.sqrt(sum / levelData.length);
+    }
+
+    function resetRecordingState() {
+      recorder = null;
+      recordedChunks = [];
+      recordingStartedAt = 0;
+      lastSpeechAt = 0;
+      sawSpeech = false;
+      discardPendingBlob = false;
+    }
+
+    async function transcribeBlob(blob) {
+      pendingTranscription = true;
+      try {
+        var audioBase64 = await blobToBase64(blob);
+        var response = await getFetchImpl()(transcribeUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            audioBase64: audioBase64,
+            mimeType: blob.type || 'audio/webm'
+          })
+        });
+        if (!response.ok) {
+          throw new Error('Transcription failed with status ' + response.status);
+        }
+        var payload = await response.json();
+        var transcript = payload && payload.text ? String(payload.text).trim() : '';
+        if (!transcript) {
+          emitter.emit('error', { error: 'no-speech', message: '', provider: 'backend', raw: payload });
+          return;
+        }
+        emitter.emit('result', {
+          transcript: transcript,
+          isFinal: true,
+          language: payload && payload.language ? String(payload.language) : '',
+          raw: payload,
+          provider: 'backend'
+        });
+      } catch (err) {
+        emitUnavailable(err && err.message ? err.message : 'Backend transcription unavailable', 'network');
+      } finally {
+        pendingTranscription = false;
+      }
+    }
+
+    function stopRecorder() {
+      if (!recorder || recorder.state === 'inactive') return;
+      try {
+        recorder.stop();
+      } catch (err) {
+        emitter.emit('error', { error: 'stop-failed', message: String(err || ''), raw: err, provider: 'backend' });
+      }
+    }
+
+    function startRecorder() {
+      if (!mediaStream || recorder || pendingTranscription) return;
+
+      recordedChunks = [];
+      discardPendingBlob = false;
+
+      var recorderOptions = {};
+      var mimeType = pickRecorderMimeType();
+      if (mimeType) recorderOptions.mimeType = mimeType;
+
+      try {
+        recorder = new MediaRecorderCtor(mediaStream, recorderOptions);
+      } catch (err) {
+        emitter.emit('error', { error: 'start-failed', message: String(err || ''), raw: err, provider: 'backend' });
+        return;
+      }
+
+      recordingStartedAt = Date.now();
+      lastSpeechAt = recordingStartedAt;
+      sawSpeech = false;
+
+      recorder.ondataavailable = function (event) {
+        if (event && event.data && event.data.size > 0) {
+          recordedChunks.push(event.data);
+        }
+      };
+
+      recorder.onerror = function (event) {
+        emitter.emit('error', {
+          error: 'audio-capture',
+          message: event && event.error ? String(event.error.message || event.error.name || '') : '',
+          raw: event,
+          provider: 'backend'
+        });
+      };
+
+      recorder.onstop = function () {
+        var shouldDiscard = discardPendingBlob || !shouldRun || !sawSpeech;
+        var blob = new window.Blob(recordedChunks, { type: recorder && recorder.mimeType ? recorder.mimeType : mimeType || 'audio/webm' });
+        resetRecordingState();
+        if (shouldDiscard || blob.size === 0) {
+          if (shouldRun && started && !pendingTranscription && !recorder) {
+            startRecorder();
+            return;
+          }
+          if (!shouldRun && !pendingTranscription) finalizeStop();
+          return;
+        }
+        transcribeBlob(blob).finally(function () {
+          if (shouldRun && started && !recorder) {
+            startRecorder();
+            return;
+          }
+          if (!shouldRun && !recorder) finalizeStop();
+        });
+      };
+
+      try {
+        recorder.start(250);
+      } catch (err2) {
+        recorder = null;
+        emitter.emit('error', { error: 'start-failed', message: String(err2 || ''), raw: err2, provider: 'backend' });
+      }
+    }
+
+    function monitorAudio() {
+      if (!shouldRun || !started || pendingTranscription) return;
+      if (!recorder) {
+        startRecorder();
+        return;
+      }
+      var level = getAudioLevel();
+      var now = Date.now();
+
+      if (level >= levelThreshold) {
+        lastSpeechAt = now;
+        sawSpeech = true;
+        return;
+      }
+
+      if (now - recordingStartedAt >= maxRecordingMs) {
+        stopRecorder();
+        return;
+      }
+
+      if (sawSpeech && now - lastSpeechAt >= silenceMs && now - recordingStartedAt >= minSpeechMs) {
+        stopRecorder();
+      }
+    }
+
+    function mapCaptureError(err) {
+      var name = err && err.name ? String(err.name) : '';
+      if (name === 'NotAllowedError' || name === 'SecurityError') {
+        return { error: 'not-allowed', message: String(err && err.message ? err.message : '') };
+      }
+      if (name === 'NotFoundError' || name === 'NotReadableError' || name === 'AbortError') {
+        return { error: 'audio-capture', message: String(err && err.message ? err.message : '') };
+      }
+      return { error: 'start-failed', message: String(err && err.message ? err.message : '') };
+    }
+
+    return {
+      start: function () {
+        if (started || starting) return;
+        shouldRun = true;
+        starting = true;
+
+        probeBackend().then(function (available) {
+          if (!available) {
+            shouldRun = false;
+            starting = false;
+            emitUnavailable('Backend transcription unavailable');
+            return;
+          }
+
+          return getMediaDevices().getUserMedia({ audio: true }).then(function (stream) {
+            if (!shouldRun) {
+              try {
+                stream.getTracks().forEach(function (track) { track.stop(); });
+              } catch (_err) {
+                // ignore
+              }
+              starting = false;
+              return;
+            }
+
+            mediaStream = stream;
+            audioContext = new AudioContextCtor();
+            return Promise.resolve(audioContext.resume && audioContext.resume()).catch(function () {
+              return undefined;
+            }).then(function () {
+              sourceNode = audioContext.createMediaStreamSource(mediaStream);
+              analyserNode = audioContext.createAnalyser();
+              analyserNode.fftSize = 2048;
+              analyserNode.smoothingTimeConstant = 0.1;
+              levelData = new Uint8Array(analyserNode.fftSize);
+              sourceNode.connect(analyserNode);
+              started = true;
+              starting = false;
+              startRecorder();
+              emitter.emit('start', { provider: 'backend' });
+              monitorTimer = setInterval(monitorAudio, Math.max(40, checkIntervalMs));
+            });
+          });
+        }).catch(function (err) {
+          shouldRun = false;
+          starting = false;
+          var mapped = mapCaptureError(err);
+          emitter.emit('error', {
+            error: mapped.error,
+            message: mapped.message,
+            raw: err,
+            provider: 'backend'
+          });
+        });
+      },
+      stop: function (opts) {
+        opts = opts || {};
+        shouldRun = false;
+        suppressEnd = !!opts.silent;
+        discardPendingBlob = true;
+        if (recorder && recorder.state !== 'inactive') {
+          stopRecorder();
+          return;
+        }
+        finalizeStop();
+      },
+      on: emitter.on
+    };
+  }
+
+  function createRecognizer(options) {
+    options = options || {};
+    var emitter = createEmitter();
+    var nativeRecognizer = supportsNativeRecognition() ? createNativeRecognizer(options) : null;
+    var backendRecognizer = supportsBackendRecognition() && options.preferBackend !== false
+      ? createBackendRecognizer(options)
+      : null;
+    var activeRecognizer = null;
+    var desiredRunning = false;
+    var backendDisabled = !backendRecognizer;
+    var suppressBackendEnd = false;
+
+    function switchToNativeFromBackend() {
+      if (!nativeRecognizer) return false;
+      backendDisabled = true;
+      suppressBackendEnd = true;
+      if (activeRecognizer === backendRecognizer) {
+        backendRecognizer.stop({ silent: true });
+      }
+      activeRecognizer = nativeRecognizer;
+      nativeRecognizer.start();
+      return true;
+    }
+
+    function forward(recognizer, type) {
+      if (!recognizer) return;
+      recognizer.on(type, function (payload) {
+        if (recognizer === backendRecognizer && type === 'error') {
+          var code = payload && payload.error ? String(payload.error) : '';
+          if (code === 'no-speech') {
+            if (desiredRunning && switchToNativeFromBackend()) {
+              return;
+            }
+          }
+        }
+        if (type === 'start' || type === 'end') {
+          if (recognizer !== activeRecognizer) return;
+          if (type === 'end' && suppressBackendEnd && recognizer === backendRecognizer) {
+            suppressBackendEnd = false;
+            return;
+          }
+        }
+        emitter.emit(type, payload);
+      });
+    }
+
+    forward(nativeRecognizer, 'result');
+    forward(nativeRecognizer, 'error');
+    forward(nativeRecognizer, 'start');
+    forward(nativeRecognizer, 'end');
+    forward(backendRecognizer, 'result');
+    forward(backendRecognizer, 'error');
+    forward(backendRecognizer, 'start');
+    forward(backendRecognizer, 'end');
+
+    if (backendRecognizer) {
+      backendRecognizer.on('unavailable', function (payload) {
+        backendDisabled = true;
+        if (desiredRunning && switchToNativeFromBackend()) {
+          return;
+        }
+        emitter.emit('error', payload);
+      });
+    }
+
+    return {
+      start: function () {
+        desiredRunning = true;
+        if (!backendDisabled && backendRecognizer) {
+          activeRecognizer = backendRecognizer;
+          backendRecognizer.start();
+          return;
+        }
+        if (nativeRecognizer) {
+          activeRecognizer = nativeRecognizer;
+          nativeRecognizer.start();
+          return;
+        }
+        throw new Error('Speech recognition not supported');
+      },
+      stop: function () {
+        desiredRunning = false;
+        if (!activeRecognizer) return;
+        activeRecognizer.stop();
+        activeRecognizer = null;
+      },
+      on: emitter.on
+    };
+  }
+
+  function speak(text, opts) {
     return new Promise(function (resolve) {
       try {
         var synth = window.speechSynthesis;
@@ -179,6 +749,8 @@
           return resolve();
         }
         var utterance = new window.SpeechSynthesisUtterance(String(text || ''));
+        var lang = opts && opts.lang ? String(opts.lang).trim() : '';
+        if (lang) utterance.lang = lang;
         utterance.onend = function () {
           resolve();
         };
@@ -194,6 +766,8 @@
 
   window.NavableSpeech = {
     supportsRecognition: supportsRecognition,
+    supportsBackendRecognition: supportsBackendRecognition,
+    supportsNativeRecognition: supportsNativeRecognition,
     createRecognizer: createRecognizer,
     speak: speak
   };

--- a/dist/src/content.js
+++ b/dist/src/content.js
@@ -35,12 +35,79 @@
     }
   }
 
+  var i18n = window.NavableI18n || null;
+
+  function normalizeOutputLanguage(lang) {
+    if (i18n && typeof i18n.normalizeLanguage === 'function') {
+      return i18n.normalizeLanguage(lang);
+    }
+    return String(lang || 'en').toLowerCase().split(/[-_]/)[0] || 'en';
+  }
+
+  function outputLocale(lang) {
+    if (i18n && typeof i18n.localeForLanguage === 'function') {
+      return i18n.localeForLanguage(lang);
+    }
+    return String(lang || 'en-US');
+  }
+
+  function currentOutputLanguage() {
+    return normalizeOutputLanguage(outputLanguage || settings.language || recogLang || 'en-US');
+  }
+
+  function translate(key, params, lang) {
+    var resolvedLang = normalizeOutputLanguage(lang || currentOutputLanguage());
+    if (i18n && typeof i18n.t === 'function') {
+      return i18n.t(key, resolvedLang, params);
+    }
+    return key;
+  }
+
+  function ensureOutputLanguageReady(lang) {
+    var resolvedLang = normalizeOutputLanguage(lang || currentOutputLanguage());
+    if (i18n && typeof i18n.ensureLanguage === 'function') {
+      return i18n.ensureLanguage(resolvedLang);
+    }
+    return Promise.resolve();
+  }
+
+  function resolveTranscriptLanguage(text) {
+    if (i18n && typeof i18n.resolveOutputLanguage === 'function') {
+      return i18n.resolveOutputLanguage({
+        transcript: text,
+        fallbackLanguage: currentOutputLanguage()
+      });
+    }
+    return currentOutputLanguage();
+  }
+
+  function localizeTarget(target, lang) {
+    var resolved = normalizeOutputLanguage(lang || currentOutputLanguage());
+    if (target === 'link') return translate('target_link', null, resolved);
+    if (target === 'button') return translate('target_button', null, resolved);
+    if (target === 'heading') return translate('target_heading', null, resolved);
+    if (target === 'input') return translate('target_input', null, resolved);
+    return translate('target_element', null, resolved);
+  }
+
+  function setOutputLanguageFromTranscript(text, detectedLanguage) {
+    if (detectedLanguage) {
+      outputLanguage = normalizeOutputLanguage(detectedLanguage);
+      return outputLanguage;
+    }
+    outputLanguage = resolveTranscriptLanguage(text);
+    return outputLanguage;
+  }
+
   // Fallback hotkey: Alt+Shift+;
   document.addEventListener(
     'keydown',
     (e) => {
       if (e.altKey && e.shiftKey && e.key === ';') {
-        announce('Navable: test announcement (fallback hotkey).', { mode: 'polite' });
+        announce(translate('navable_test_announcement'), {
+          mode: 'polite',
+          lang: outputLocale(currentOutputLanguage())
+        });
       }
     },
     { capture: true }
@@ -50,12 +117,23 @@
   if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.onMessage) {
     chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       if (msg && msg.type === 'announce') {
-        announce(msg.text || 'Navable: announcement.', { mode: msg.mode || 'polite', priority: !!msg.priority });
+        announce(msg.text || translate('generic_announcement'), {
+          mode: msg.mode || 'polite',
+          priority: !!msg.priority,
+          lang: msg.lang || outputLocale(currentOutputLanguage())
+        });
         return;
       }
       if (msg && msg.type === 'navable:announce') {
-        announce(msg.text || 'Navable: announcement.', { mode: msg.mode || 'polite', priority: !!msg.priority });
-        sendResponse && sendResponse({ ok: true });
+        if (msg.lang) outputLanguage = normalizeOutputLanguage(msg.lang);
+        ensureOutputLanguageReady(outputLanguage).finally(function () {
+          announce(msg.text || translate('generic_announcement'), {
+            mode: msg.mode || 'polite',
+            priority: !!msg.priority,
+            lang: msg.lang || outputLocale(currentOutputLanguage())
+          });
+          sendResponse && sendResponse({ ok: true });
+        });
         return true;
       }
       if (msg && msg.type === 'navable:getStructure') {
@@ -121,7 +199,10 @@
   // Speak on activation (top window only)
   try {
     if (window.top === window) {
-      announce('Navable is ready. Say “help” to hear example commands.', { mode: 'polite' });
+      announce(translate('navable_ready'), {
+        mode: 'polite',
+        lang: outputLocale(currentOutputLanguage())
+      });
     }
   } catch (_e) {
     // ignore cross-origin frame access errors
@@ -551,7 +632,7 @@
       return { ok: true, message: 'Moved heading ' + (dir === 'prev' ? 'previous' : 'next') };
     }
     if (action === 'wait_for_user_input') {
-      speak(step.prompt || 'Please provide input, then tell me to continue.');
+      speak(step.prompt || translate('wait_for_user_input'));
       return { ok: true, message: 'Waiting for user input' };
     }
     return { ok: false, message: 'Unknown action ' + action };
@@ -589,6 +670,7 @@
   var lastUnknownCmdAt = 0;
   var lastMicBusyAt = 0;
   var recogLang = 'en-US';
+  var outputLanguage = 'en';
   var transientRestoreTimer = null;
   var startRetryTimer = null;
   var startRetryCount = 0;
@@ -617,12 +699,13 @@
     var msg = String(text || '');
     var isTransient = !!opts.transient;
     var restoreMs = typeof opts.restoreMs === 'number' ? opts.restoreMs : 2500;
+    var lang = opts && opts.lang ? String(opts.lang) : outputLocale(currentOutputLanguage());
 
     if (!isTransient) {
       lastSpoken = msg;
       clearTransientRestoreTimer();
       // Rely on the ARIA live region + screen reader; do not use browser text-to-speech.
-      announce(lastSpoken, { mode: mode });
+      announce(lastSpoken, { mode: mode, lang: lang });
       return;
     }
 
@@ -634,7 +717,7 @@
     } catch (_err) {
       previousText = '';
     }
-    announce(msg, { mode: mode });
+    announce(msg, { mode: mode, lang: lang });
 
     clearTransientRestoreTimer();
     transientRestoreTimer = setTimeout(function () {
@@ -688,7 +771,10 @@
   function ensureRecognizer() {
     if (recognizer || !isVoiceSupported()) return recognizer;
     recognizer = speech.createRecognizer({ lang: recogLang || 'en-US', interimResults: false, continuous: true, autoRestart: true });
-    recognizer.on('result', function (ev) { if (!ev || !ev.transcript) return; handleTranscript(ev.transcript); });
+    recognizer.on('result', function (ev) {
+      if (!ev || !ev.transcript) return;
+      handleTranscript(ev.transcript, ev.language || '');
+    });
     recognizer.on('error', function (e) {
       console.warn('[Navable] speech error', e && e.error);
       try {
@@ -699,7 +785,7 @@
             var now2 = Date.now();
             if (now2 - lastMicBusyAt > 15000) {
               lastMicBusyAt = now2;
-              speakTransient('Microphone is busy in another tab or app. Retrying…', 3500);
+              speakTransient(translate('microphone_busy_retry'), 3500);
             }
             clearStartRetryTimer();
             startRetryCount = Math.min(10, startRetryCount + 1);
@@ -718,13 +804,13 @@
 	        } else if (code === 'not-allowed' || code === 'service-not-allowed') {
 	          listening = false;
 	          manualListening = false;
-	          speak('Speech recognition is not allowed in this browser.');
+	          speak(translate('speech_not_allowed'));
 	        } else if (code === 'network') {
 	          listening = false;
 	          manualListening = false;
-	          speak('Speech recognition is unavailable due to a network issue.');
+	          speak(translate('speech_network_issue'));
 	        } else {
-	          speak('Speech recognition had a problem. Please try again.');
+	          speak(translate('speech_problem_retry'));
 	        }
       } catch (_err) {
         // ignore secondary failures
@@ -745,12 +831,12 @@
     startRetryCount = 0;
     ensureRecognizer();
     if (!recognizer) {
-      if (opts.announce !== false) speak('Speech recognition not available.');
+      if (opts.announce !== false) speak(translate('speech_not_available'));
       listening = false;
       return;
     }
     listening = true;
-    if (opts.announce) speak('Listening. Say “help” to hear example commands.');
+    if (opts.announce) speak(translate('listening_help'));
     try { recognizer.start(); } catch (_err) { /* errors are handled via recognizer error events */ }
   }
 
@@ -759,7 +845,7 @@
     listening = false;
     clearStartRetryTimer();
     startRetryCount = 0;
-    if (opts.announce) speak('Stopped listening. Press Alt+Shift+M to start again.');
+    if (opts.announce) speak(translate('stopped_listening'));
     try { if (recognizer) recognizer.stop(); } catch (_err) { /* ignore */ }
   }
 
@@ -804,22 +890,56 @@
     // ignore
   }
 
+  function matchesAnyPattern(text, patterns) {
+    for (var i = 0; i < patterns.length; i++) {
+      if (patterns[i].test(text)) return true;
+    }
+    return false;
+  }
+
+  function extractSearchSiteQuery(t) {
+    var s = String(t || '').trim().toLowerCase();
+    if (!s) return null;
+
+    var en = s.match(/^(search|google|look up|find)\s+(for\s+)?(.+)$/);
+    if (en && en[3]) return 'search for ' + String(en[3]).trim();
+
+    var fr = s.match(/^(cherche|recherche)\s+(.+)$/);
+    if (fr && fr[2]) return 'search for ' + String(fr[2]).trim();
+
+    var ar = s.match(/^(ابحث|فتش)(\s+عن)?\s+(.+)$/);
+    if (ar && ar[3]) return 'search for ' + String(ar[3]).trim();
+
+    return null;
+  }
+
   function extractOpenSiteQuery(t) {
     var s = String(t || '').trim().toLowerCase();
     if (!s) return null;
 
     // Avoid conflicting with in-page intents like "open first link" or "press button".
-    if (/\b(link|button|heading)\b/.test(s)) return null;
+    if (/\b(link|button|heading|lien|bouton|titre)\b|رابط|زر|عنوان/.test(s)) return null;
 
-    // Arabic: "افتح <شيء>"
-    var ar = s.match(/^افتح\s+(.+)$/);
-    if (ar && ar[1]) return String(ar[1]).trim();
+    // Arabic website intents.
+    var ar = s.match(/^(افتح|اذهب\s+إلى|اذهب\s+الى|روح\s+على|روح\s+إلى|روح\s+الى|انتقل\s+إلى|انتقل\s+الى)\s+(.+)$/);
+    if (ar && ar[2]) return String(ar[2]).trim();
 
-    // English: "open (me) <site>"
-    if (!/^(open|navigate to|take me to)\b/.test(s)) return null;
+    // French website intents.
+    var fr = s.match(/^(ouvre|va(?:s)?\s+(?:a|à)|aller?\s+(?:a|à)|visite|lance)\s+(.+)$/);
+    if (fr && fr[2]) {
+      return String(fr[2])
+        .trim()
+        .replace(/^(le|la|les|un|une)\b/, '')
+        .trim()
+        .replace(/^(site|page|onglet)\b/, '')
+        .trim();
+    }
+
+    // English: flexible website intents.
+    if (!/^(open|navigate to|take me to|go to|visit|bring up|launch)\b/.test(s)) return null;
 
     var q = s
-      .replace(/^(open(\s+up)?|navigate to|take me to)\b/, '')
+      .replace(/^(open(\s+up)?|navigate to|take me to|go to|visit|bring up|launch)\b/, '')
       .trim()
       .replace(/^(me|for me)\b/, '')
       .trim()
@@ -846,11 +966,14 @@
     var label;
 
     // Help / examples.
-    if (/^(help|help me|commands|show commands|what can i say\??)$/.test(t) || /مساعدة/.test(t)) {
+    if (
+      /^(help|help me|commands|show commands|what can i say\??|aide|montre les commandes|que puis-je dire\??)$/.test(t) ||
+      /مساعدة/.test(t)
+    ) {
       return { type: 'help' };
     }
 
-    // English summary triggers + common Arabic phrasing.
+    // Summary/orientation triggers in English, French, and Arabic.
     if (
       t.includes('summarize') ||
       t.includes('summary') ||
@@ -859,6 +982,10 @@
       t.includes("what's on this page") ||
       t.includes('what is on this page') ||
       t.includes("what's this page") ||
+      /r[ée]sum[ée]?.*cette page/.test(t) ||
+      /d[ée]cri(s|re).*cette page/.test(t) ||
+      /c[' ]?est quoi cette page/.test(t) ||
+      /qu[' ]?est[- ]ce que cette page/.test(t) ||
       /ما هذه الصفحه/.test(t) ||
       /ما هذه الصفحة/.test(t) ||
       /ما هو محتوى الصفحة/.test(t) ||
@@ -868,17 +995,20 @@
       return { type: 'summarize', command: original || 'Summarize this page' };
     }
 
+    var searchQuery = extractSearchSiteQuery(t);
+    if (searchQuery) return { type: 'open_site', query: searchQuery, newTab: true };
+
     // Open a new website (dynamic) in a new tab.
     var siteQuery = extractOpenSiteQuery(t);
     if (siteQuery) return { type: 'open_site', query: siteQuery, newTab: true };
 
-    if (/(scroll )?down/.test(t) || /scroll down/.test(t)) return { type: 'scroll', dir: 'down' };
-    if (/(scroll )?up/.test(t) || /scroll up/.test(t)) return { type: 'scroll', dir: 'up' };
-    if (/top/.test(t) || /scroll (to )?top/.test(t)) return { type: 'scroll', dir: 'top' };
-    if (/bottom/.test(t) || /scroll (to )?bottom/.test(t)) return { type: 'scroll', dir: 'bottom' };
-    if (/read (the )?title/.test(t) || /read title/.test(t)) return { type: 'read', what: 'title' };
-    if (/^read (the )?selection/.test(t) || /^read selected/.test(t)) return { type: 'read', what: 'selection' };
-    if (/^read (the )?(focus|focused|this)$/.test(t)) return { type: 'read', what: 'focused' };
+    if (matchesAnyPattern(t, [/(scroll )?down/, /scroll down/, /\bdescend(s)?\b/, /plus bas/, /انزل|نز[ّل]|مرر.*(للأسفل|للاسفل)/])) return { type: 'scroll', dir: 'down' };
+    if (matchesAnyPattern(t, [/(scroll )?up/, /scroll up/, /\bmonte\b/, /plus haut/, /اطلع|اصعد|مرر.*(للأعلى|للاعلى)/])) return { type: 'scroll', dir: 'up' };
+    if (matchesAnyPattern(t, [/\btop\b/, /scroll (to )?top/, /en haut/, /أعلى الصفحة|اعلى الصفحة/])) return { type: 'scroll', dir: 'top' };
+    if (matchesAnyPattern(t, [/\bbottom\b/, /scroll (to )?bottom/, /en bas/, /أسفل الصفحة|اسفل الصفحة/])) return { type: 'scroll', dir: 'bottom' };
+    if (matchesAnyPattern(t, [/read (the )?title/, /read title/, /lis le titre/, /quel est le titre/, /اقر[أا] العنوان|ما عنوان الصفحة/])) return { type: 'read', what: 'title' };
+    if (matchesAnyPattern(t, [/^read (the )?selection/, /^read selected/, /lis la s[ée]lection/, /اقر[أا] التحديد/])) return { type: 'read', what: 'selection' };
+    if (matchesAnyPattern(t, [/^read (the )?(focus|focused|this)$/, /sur quoi suis[- ]je/, /ما العنصر المحدد|على ماذا انا|على ماذا أنا/])) return { type: 'read', what: 'focused' };
 
     // Explicit label-based intents first
     if ((/^open/.test(t) || /^click/.test(t)) && /link/.test(t) && (label = extractLabel(t, 'link'))) return { type: 'open', target: 'link', label: label };
@@ -918,8 +1048,8 @@
     if (/next .*heading/.test(t) || /^next heading/.test(t)) return { type: 'move', target: 'heading', dir: 'next' };
     if (/previous .*heading/.test(t) || /^previous heading/.test(t) || /prev .*heading/.test(t)) return { type: 'move', target: 'heading', dir: 'prev' };
 
-    if (/repeat/.test(t)) return { type: 'repeat' };
-    if (/stop/.test(t)) return { type: 'stop' };
+    if (/repeat|r[ée]p[èe]te|كرر/.test(t)) return { type: 'repeat' };
+    if (/stop|arr[êe]te|stoppe|توقف|قف|اسكت/.test(t)) return { type: 'stop' };
     return null;
   }
 
@@ -1028,7 +1158,7 @@
       var now = Date.now();
       if (now - lastUnknownCmdAt < 5000) return;
       lastUnknownCmdAt = now;
-      speakTransient('I did not catch that. Say “help” to hear example commands.', 3200);
+      speakTransient(translate('unknown_command'), 3200);
       return;
     }
     if (cmd.type === 'help') { speakHelp(); return; }
@@ -1040,19 +1170,19 @@
       var amount = Math.floor(window.innerHeight * 0.8);
       if (cmd.dir === 'down') {
         window.scrollBy({ top: amount, behavior: 'smooth' });
-        speak('Scrolled down.');
+        speak(translate('scrolled_down'));
       } else if (cmd.dir === 'up') {
         window.scrollBy({ top: -amount, behavior: 'smooth' });
-        speak('Scrolled up.');
+        speak(translate('scrolled_up'));
       } else if (cmd.dir === 'top') {
         window.scrollTo({ top: 0, behavior: 'smooth' });
-        speak('Scrolled to top.');
+        speak(translate('scrolled_top'));
       } else if (cmd.dir === 'bottom') {
         window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
-        speak('Scrolled to bottom.');
+        speak(translate('scrolled_bottom'));
       } else {
         window.scrollBy({ top: amount, behavior: 'smooth' });
-        speak('Scrolled down.');
+        speak(translate('scrolled_down'));
       }
       console.log('[Navable] Action: scroll', cmd.dir);
       return;
@@ -1060,14 +1190,14 @@
     if (cmd.type === 'read' && cmd.what === 'title') {
       var h1 = document.querySelector('h1');
       var title = (h1 && h1.innerText) || document.title || '';
-      speak('Title: ' + (title || 'not found'));
+      speak(translate('title_value', { value: title || translate('value_not_found') }));
       console.log('[Navable] Action: read title');
       return;
     }
     if (cmd.type === 'read' && cmd.what === 'selection') {
       var sel = '';
       try { sel = String(window.getSelection && window.getSelection().toString() || '').trim(); } catch (_err) { /* selection failed */ }
-      if (sel) { speak('Selection: ' + sel); } else { speak('No selection.'); }
+      if (sel) { speak(translate('selection_value', { value: sel })); } else { speak(translate('no_selection')); }
       console.log('[Navable] Action: read selection');
       return;
     }
@@ -1076,43 +1206,43 @@
       if (fe) {
         var fl = (fe.dataset && fe.dataset.navableLabel) || fe.getAttribute && fe.getAttribute('aria-label') || fe.innerText || fe.textContent || '';
         fl = String(fl || '').trim();
-        speak(fl || 'No focused element text.');
+        speak(fl || translate('no_focused_text'));
       } else {
-        speak('No focused element.');
+        speak(translate('no_focused_element'));
       }
       console.log('[Navable] Action: read focused');
       return;
     }
     if (cmd.type === 'read' && cmd.target === 'heading' && cmd.label) {
       var elhL = findByLabel('heading', cmd.label);
-      if (!elhL) { speak('I did not find that heading.'); return; }
+      if (!elhL) { speak(translate('not_found_heading')); return; }
       var lblhL = elhL.dataset.navableLabel || elhL.innerText || elhL.textContent || '';
-      speak('Heading: ' + (lblhL.trim() || 'unnamed'));
+      speak(translate('heading_value', { value: lblhL.trim() || translate('unnamed') }));
       console.log('[Navable] Action: read heading by label', cmd.label);
       return;
     }
     if (cmd.type === 'read' && cmd.target === 'heading' && !cmd.label) {
       var elh = pickNth('heading', cmd.n || 1);
-      if (!elh) { speak('I did not find a heading.'); return; }
+      if (!elh) { speak(translate('not_found_generic', { target: localizeTarget('heading') })); return; }
       var lblh = elh.dataset.navableLabel || elh.innerText || elh.textContent || '';
-      speak('Heading: ' + (lblh.trim() || 'unnamed'));
+      speak(translate('heading_value', { value: lblh.trim() || translate('unnamed') }));
       console.log('[Navable] Action: read heading', cmd.n);
       return;
     }
     if (cmd.type === 'open' && cmd.target === 'link' && cmd.label) {
       var ellL = findByLabel('link', cmd.label);
-      if (!ellL) { speak('I did not find that link.'); return; }
+      if (!ellL) { speak(translate('not_found_link')); return; }
       var lbllL = ellL.dataset.navableLabel || ellL.innerText || ellL.textContent || '';
-      speak('Opening ' + (lbllL.trim() || 'link'));
+      speak(translate('opening_value', { value: lbllL.trim() || translate('target_link') }));
       ellL.click();
       console.log('[Navable] Action: open link by label', cmd.label);
       return;
     }
     if (cmd.type === 'open' && cmd.target === 'link' && !cmd.label) {
       var ell = pickNth('link', cmd.n || 1);
-      if (!ell) { speak('I did not find a link.'); return; }
+      if (!ell) { speak(translate('not_found_generic', { target: localizeTarget('link') })); return; }
       var lbll = ell.dataset.navableLabel || ell.innerText || ell.textContent || '';
-      speak('Opening ' + (lbll.trim() || 'link'));
+      speak(translate('opening_value', { value: lbll.trim() || translate('target_link') }));
       // Prefer click to follow anchors and SPA handlers
       ell.click();
       console.log('[Navable] Action: open link', cmd.n);
@@ -1120,70 +1250,70 @@
     }
     if (cmd.type === 'focus' && cmd.target === 'button' && cmd.label) {
       var elbL = findByLabel('button', cmd.label);
-      if (!elbL) { speak('I did not find that button.'); return; }
+      if (!elbL) { speak(translate('not_found_button')); return; }
       try { elbL.focus(); } catch (_err) { /* focus failed */ }
       var lblbL = elbL.dataset.navableLabel || elbL.innerText || elbL.textContent || '';
-      speak('Focused ' + (lblbL.trim() || 'button'));
+      speak(translate('focused_value', { value: lblbL.trim() || translate('target_button') }));
       console.log('[Navable] Action: focus button by label', cmd.label);
       return;
     }
     if (cmd.type === 'focus' && cmd.target === 'button' && !cmd.label) {
       var elb = pickNth('button', cmd.n || 1);
-      if (!elb) { speak('I did not find a button.'); return; }
+      if (!elb) { speak(translate('not_found_generic', { target: localizeTarget('button') })); return; }
       try { elb.focus(); } catch (_err) { /* focus failed */ }
       var lblb = elb.dataset.navableLabel || elb.innerText || elb.textContent || '';
-      speak('Focused ' + (lblb.trim() || 'button'));
+      speak(translate('focused_value', { value: lblb.trim() || translate('target_button') }));
       console.log('[Navable] Action: focus button', cmd.n);
       return;
     }
     if (cmd.type === 'activate' && cmd.target === 'focused') {
       var aef = document.activeElement;
-      if (!aef) { speak('No focused element.'); return; }
+      if (!aef) { speak(translate('no_focused_element')); return; }
       var labf = (aef.dataset && aef.dataset.navableLabel) || aef.getAttribute && aef.getAttribute('aria-label') || aef.innerText || aef.textContent || '';
       labf = String(labf || '').trim();
       try { aef.click(); } catch (_err) { /* click failed */ }
-      speak('Activated ' + (labf || 'element'));
+      speak(translate('activated_value', { value: labf || translate('target_element') }));
       console.log('[Navable] Action: activate focused');
       return;
     }
     if (cmd.type === 'activate' && cmd.target === 'button' && cmd.label) {
       var ab = findByLabel('button', cmd.label);
-      if (!ab) { speak('I did not find that button.'); return; }
+      if (!ab) { speak(translate('not_found_button')); return; }
       var labb = ab.dataset.navableLabel || ab.innerText || ab.textContent || '';
       try { ab.focus(); } catch (_err) { /* focus failed */ }
       try { ab.click(); } catch (_err) { /* click failed */ }
-      speak('Activated ' + (String(labb || 'button').trim()));
+      speak(translate('activated_value', { value: String(labb || translate('target_button')).trim() }));
       console.log('[Navable] Action: activate button by label', cmd.label);
       return;
     }
     if (cmd.type === 'activate' && cmd.target === 'button' && cmd.n != null) {
       var abin = pickNth('button', cmd.n);
-      if (!abin) { speak('I did not find a button.'); return; }
+      if (!abin) { speak(translate('not_found_generic', { target: localizeTarget('button') })); return; }
       var labbn = abin.dataset.navableLabel || abin.innerText || abin.textContent || '';
       try { abin.focus(); } catch (_err) { /* focus failed */ }
       try { abin.click(); } catch (_err) { /* click failed */ }
-      speak('Activated ' + (String(labbn || 'button').trim()));
+      speak(translate('activated_value', { value: String(labbn || translate('target_button')).trim() }));
       console.log('[Navable] Action: activate button', cmd.n);
       return;
     }
     if (cmd.type === 'move' && (cmd.target === 'link' || cmd.target === 'button')) {
       var elmv = moveBy(cmd.target, cmd.dir === 'prev' ? 'prev' : 'next');
-      if (!elmv) { speak('I did not find a ' + cmd.target + '.'); return; }
+      if (!elmv) { speak(translate('not_found_generic', { target: localizeTarget(cmd.target) })); return; }
       try { elmv.focus(); } catch (_err) { /* focus failed */ }
       var lblmv = elmv.dataset.navableLabel || elmv.innerText || elmv.textContent || '';
-      speak('Focused ' + (lblmv.trim() || cmd.target));
+      speak(translate('focused_value', { value: lblmv.trim() || localizeTarget(cmd.target) }));
       console.log('[Navable] Action: move ' + cmd.target, cmd.dir);
       return;
     }
     if (cmd.type === 'move' && cmd.target === 'heading') {
       var elmh = moveBy('heading', cmd.dir === 'prev' ? 'prev' : 'next');
-      if (!elmh) { speak('I did not find a heading.'); return; }
+      if (!elmh) { speak(translate('not_found_generic', { target: localizeTarget('heading') })); return; }
       var lblmh = elmh.dataset.navableLabel || elmh.innerText || elmh.textContent || '';
       if (!elmh.hasAttribute('tabindex')) {
         try { elmh.setAttribute('tabindex', '-1'); } catch (_err) { /* ignore */ }
       }
       try { elmh.focus(); } catch (_err) { /* focus failed */ }
-      speak('Heading: ' + (lblmh.trim() || 'unnamed'));
+      speak(translate('heading_value', { value: lblmh.trim() || translate('unnamed') }));
       console.log('[Navable] Action: move heading', cmd.dir);
       return;
     }
@@ -1193,52 +1323,104 @@
 
   async function runSummaryRequest(commandText) {
     var cmdText = (commandText && String(commandText).trim()) || 'Summarize this page';
-    announce('Summarizing this page… please wait.', { mode: 'assertive', priority: true });
+    announce(translate('summarizing_wait'), {
+      mode: 'assertive',
+      priority: true,
+      lang: outputLocale(currentOutputLanguage())
+    });
     if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) {
-      announce('Sorry — summarization is unavailable on this page.', { mode: 'assertive', priority: true });
+      announce(translate('summarize_unavailable_page'), {
+        mode: 'assertive',
+        priority: true,
+        lang: outputLocale(currentOutputLanguage())
+      });
       return;
     }
     try {
-      var res = await chrome.runtime.sendMessage({ type: 'planner:run', command: cmdText });
+      var res = await chrome.runtime.sendMessage({
+        type: 'planner:run',
+        command: cmdText,
+        outputLanguage: currentOutputLanguage()
+      });
       if (!res || res.ok !== true) {
-        announce((res && res.error) ? String(res.error) : 'Sorry — I could not summarize this page.', { mode: 'assertive', priority: true });
+        announce((res && res.error) ? String(res.error) : translate('summarize_failed'), {
+          mode: 'assertive',
+          priority: true,
+          lang: outputLocale(currentOutputLanguage())
+        });
       }
       // On success, the background will announce the summary via the live region.
     } catch (err) {
       console.warn('[Navable] summarize via planner failed', err);
-      announce('Sorry — the summary request failed. Please try again.', { mode: 'assertive', priority: true });
+      announce(translate('summarize_request_failed'), {
+        mode: 'assertive',
+        priority: true,
+        lang: outputLocale(currentOutputLanguage())
+      });
     }
   }
 
   async function openSiteRequest(query, newTab) {
     var q = String(query || '').trim();
     if (!q) {
-      speak('Tell me which website to open.');
+      speak(translate('tell_website_to_open'));
       return;
     }
     if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) {
-      speak('Opening a website is unavailable.');
+      speak(translate('open_site_unavailable'));
       return;
     }
     try {
-      var res = await chrome.runtime.sendMessage({ type: 'navable:openSite', query: q, newTab: newTab !== false });
+      var res = await chrome.runtime.sendMessage({
+        type: 'navable:openSite',
+        query: q,
+        newTab: newTab !== false,
+        outputLanguage: currentOutputLanguage()
+      });
       if (!res || res.ok !== true) {
-        speak((res && res.error) ? String(res.error) : 'Could not open that site.');
+        speak((res && res.error) ? String(res.error) : translate('open_site_failed'));
       }
     } catch (err) {
       console.warn('[Navable] open site via background failed', err);
-      speak('Could not open that site.');
+      speak(translate('open_site_failed'));
     }
   }
 
-  function handleTranscript(text) {
+  async function tryIntentFallback(commandText) {
+    if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) return false;
+    try {
+      var res = await chrome.runtime.sendMessage({
+        type: 'planner:run',
+        command: commandText,
+        outputLanguage: currentOutputLanguage(),
+        preferIntentFallback: true
+      });
+      return !!(res && res.ok === true && (
+        (res.plan && res.plan.steps && res.plan.steps.length) ||
+        res.description ||
+        res.summary
+      ));
+    } catch (err) {
+      console.warn('[Navable] intent fallback failed', err);
+      return false;
+    }
+  }
+
+  async function handleTranscript(text, detectedLanguage) {
     console.log('[Navable] Recognized:', text);
+    setOutputLanguageFromTranscript(text, detectedLanguage);
+    await ensureOutputLanguageReady();
     var cmd = parseCommand(text);
     if (cmd && cmd.type === 'summarize') {
-      runSummaryRequest(cmd.command);
+      await runSummaryRequest(cmd.command);
       return;
     }
-    execCommand(cmd);
+    if (cmd) {
+      execCommand(cmd);
+      return;
+    }
+    if (await tryIntentFallback(text)) return;
+    execCommand(null);
   }
 
   // Hotkey to toggle listening: Alt+Shift+M (prototype)
@@ -1266,6 +1448,7 @@
 	        settings = { language: s.language || 'en-US', overlay: !!s.overlay, autostart: autostart };
 	        settingsLoaded = true;
 	        recogLang = settings.language || 'en-US';
+	        outputLanguage = normalizeOutputLanguage(settings.language || 'en-US');
 	        if (settings.overlay) { overlayOn = true; drawOverlay(); } else { overlayOn = false; clearOverlay(); }
 	        syncListening({ announce: false });
 	      });
@@ -1276,6 +1459,7 @@
 	        settings = { language: s2.language || 'en-US', overlay: !!s2.overlay, autostart: autostart2 };
 	        settingsLoaded = true;
 	        recogLang = settings.language || 'en-US';
+	        outputLanguage = normalizeOutputLanguage(settings.language || 'en-US');
 	        if (settings.overlay) { overlayOn = true; drawOverlay(); } else { overlayOn = false; clearOverlay(); }
 	        syncListening({ announce: false });
 	      });
@@ -1284,7 +1468,7 @@
 
   // Help voice command + hotkey
   function speakHelp() {
-    speak('Try: summarize this page, scroll down, read title, next heading, open first link, activate focused, read selection. Press Alt+Shift+M to toggle listening.');
+    speak(translate('help_examples'));
   }
 
   document.addEventListener('keydown', function (e) {

--- a/dist/src/newtab/newtab.html
+++ b/dist/src/newtab/newtab.html
@@ -92,6 +92,7 @@
       </footer>
     </main>
 
+    <script src="../common/i18n.js"></script>
     <script src="../common/announce.js"></script>
     <script src="../common/speech.js"></script>
     <script src="newtab.js"></script>

--- a/dist/src/newtab/newtab.js
+++ b/dist/src/newtab/newtab.js
@@ -74,11 +74,61 @@ function announce(text, mode = 'polite') {
   if (!msg) return;
   try {
     if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
-      window.NavableAnnounce.speak(msg, { mode: mode === 'assertive' ? 'assertive' : 'polite' });
+      window.NavableAnnounce.speak(msg, {
+        mode: mode === 'assertive' ? 'assertive' : 'polite',
+        lang: outputLocale(currentOutputLanguage())
+      });
     }
   } catch (_err) {
     // ignore
   }
+}
+
+const i18n = window.NavableI18n || null;
+
+function normalizeOutputLanguage(lang) {
+  if (i18n && typeof i18n.normalizeLanguage === 'function') return i18n.normalizeLanguage(lang);
+  return String(lang || 'en').toLowerCase().split(/[-_]/)[0] || 'en';
+}
+
+function outputLocale(lang) {
+  if (i18n && typeof i18n.localeForLanguage === 'function') return i18n.localeForLanguage(lang);
+  return String(lang || 'en-US');
+}
+
+function currentOutputLanguage() {
+  return normalizeOutputLanguage(newtabOutputLanguage || newtabVoiceLang || 'en-US');
+}
+
+function translate(key, params, lang) {
+  const resolved = normalizeOutputLanguage(lang || currentOutputLanguage());
+  if (i18n && typeof i18n.t === 'function') return i18n.t(key, resolved, params);
+  return key;
+}
+
+function ensureOutputLanguageReady(lang) {
+  const resolved = normalizeOutputLanguage(lang || currentOutputLanguage());
+  if (i18n && typeof i18n.ensureLanguage === 'function') return i18n.ensureLanguage(resolved);
+  return Promise.resolve();
+}
+
+function resolveTranscriptLanguage(text) {
+  if (i18n && typeof i18n.resolveOutputLanguage === 'function') {
+    return i18n.resolveOutputLanguage({
+      transcript: text,
+      fallbackLanguage: currentOutputLanguage()
+    });
+  }
+  return currentOutputLanguage();
+}
+
+function setNewtabOutputLanguage(transcript, detectedLanguage) {
+  if (detectedLanguage) {
+    newtabOutputLanguage = normalizeOutputLanguage(detectedLanguage);
+    return newtabOutputLanguage;
+  }
+  newtabOutputLanguage = resolveTranscriptLanguage(transcript);
+  return newtabOutputLanguage;
 }
 
 function isVoiceSupported() {
@@ -100,15 +150,26 @@ function extractOpenSiteQuery(transcript) {
   const s = String(transcript || '').trim().toLowerCase();
   if (!s) return null;
 
-  // Arabic: "افتح <شيء>"
-  const ar = s.match(/^افتح\s+(.+)$/);
-  if (ar && ar[1]) return String(ar[1]).trim();
+  // Arabic website intents.
+  const ar = s.match(/^(افتح|اذهب\s+إلى|اذهب\s+الى|روح\s+على|روح\s+إلى|روح\s+الى|انتقل\s+إلى|انتقل\s+الى)\s+(.+)$/);
+  if (ar && ar[2]) return String(ar[2]).trim();
 
-  // English: "open (me) <site>"
-  if (!/^(open|navigate to|go to|take me to)\b/.test(s)) return null;
+  // French website intents.
+  const fr = s.match(/^(ouvre|va(?:s)?\s+(?:a|à)|aller?\s+(?:a|à)|visite|lance)\s+(.+)$/);
+  if (fr && fr[2]) {
+    return String(fr[2])
+      .trim()
+      .replace(/^(le|la|les|un|une)\b/, '')
+      .trim()
+      .replace(/^(site|page|onglet)\b/, '')
+      .trim();
+  }
+
+  // English: flexible website intents.
+  if (!/^(open|navigate to|go to|take me to|visit|bring up|launch)\b/.test(s)) return null;
 
   const q = s
-    .replace(/^(open(\s+up)?|navigate to|go to|take me to)\b/, '')
+    .replace(/^(open(\s+up)?|navigate to|go to|take me to|visit|bring up|launch)\b/, '')
     .trim()
     .replace(/^(me|for me)\b/, '')
     .trim()
@@ -124,23 +185,40 @@ function extractOpenSiteQuery(transcript) {
   return q || null;
 }
 
+function extractSearchQuery(transcript) {
+  const s = String(transcript || '').trim().toLowerCase();
+  if (!s) return null;
+
+  const en = s.match(/^(search|google|look up|find)\s+(for\s+)?(.+)$/);
+  if (en && en[3]) return `search for ${String(en[3]).trim()}`;
+
+  const fr = s.match(/^(cherche|recherche)\s+(.+)$/);
+  if (fr && fr[2]) return `search for ${String(fr[2]).trim()}`;
+
+  const ar = s.match(/^(ابحث|فتش)(\s+عن)?\s+(.+)$/);
+  if (ar && ar[3]) return `search for ${String(ar[3]).trim()}`;
+
+  return null;
+}
+
 function parseVoiceCommand(transcript) {
   const t = String(transcript || '').trim();
   const low = t.toLowerCase();
   if (!low) return null;
 
-  if (/^(help|commands|show commands|what can i say\??)$/.test(low) || /مساعدة/.test(low)) {
+  if (
+    /^(help|commands|show commands|what can i say\??|aide|montre les commandes|que puis-je dire\??)$/.test(low) ||
+    /مساعدة/.test(low)
+  ) {
     return { type: 'help' };
   }
 
-  if (/^(stop|stop listening|cancel)$/.test(low)) {
+  if (/^(stop|stop listening|cancel|arr[êe]te|stoppe|توقف|قف)$/.test(low)) {
     return { type: 'stop' };
   }
 
-  const searchMatch = low.match(/^(search|google)\s+(for\s+)?(.+)$/);
-  if (searchMatch && searchMatch[3]) {
-    return { type: 'open_site', query: `search for ${searchMatch[3]}` };
-  }
+  const searchQuery = extractSearchQuery(low);
+  if (searchQuery) return { type: 'open_site', query: searchQuery };
 
   const q = extractOpenSiteQuery(t);
   if (q) return { type: 'open_site', query: q };
@@ -152,6 +230,7 @@ let newtabRecognizer = null;
 let newtabWantsListening = false;
 let newtabVoiceReady = false;
 let newtabVoiceLang = 'en-US';
+let newtabOutputLanguage = 'en';
 
 function refreshNewtabMicUi() {
   const { btn, status } = getVoiceStatusEls();
@@ -204,6 +283,7 @@ async function ensureNewtabRecognizer() {
 
   const settings = await loadNewtabVoiceSettings();
   newtabVoiceLang = settings.language || 'en-US';
+  newtabOutputLanguage = normalizeOutputLanguage(newtabVoiceLang);
 
   try {
     newtabRecognizer = window.NavableSpeech.createRecognizer({
@@ -215,7 +295,7 @@ async function ensureNewtabRecognizer() {
 
     newtabRecognizer.on('result', (ev) => {
       if (!ev?.transcript) return;
-      handleNewtabTranscript(ev.transcript);
+      handleNewtabTranscript(ev.transcript, ev.language || '');
     });
 
     newtabRecognizer.on('error', (e) => {
@@ -225,23 +305,23 @@ async function ensureNewtabRecognizer() {
       if (code === 'not-allowed' || code === 'service-not-allowed') {
         newtabWantsListening = false;
         refreshNewtabMicUi();
-        setNewtabMicMessage('Microphone access is blocked. Allow microphone for this extension to use voice.', 'assertive');
+        setNewtabMicMessage(translate('mic_access_blocked'), 'assertive');
         return;
       }
 
       if (code === 'audio-capture' || code === 'aborted' || code === 'start-failed') {
-        setNewtabMicMessage('Microphone is busy. Close other apps/tabs using the mic, then try again.', 'polite');
+        setNewtabMicMessage(translate('mic_busy'), 'polite');
         return;
       }
 
       if (code === 'network') {
         newtabWantsListening = false;
         refreshNewtabMicUi();
-        setNewtabMicMessage('Speech recognition is unavailable due to a network issue.', 'assertive');
+        setNewtabMicMessage(translate('speech_network_issue'), 'assertive');
         return;
       }
 
-      setNewtabMicMessage('Speech recognition had a problem. Please try again.', 'assertive');
+      setNewtabMicMessage(translate('speech_problem_retry'), 'assertive');
     });
 
     newtabRecognizer.on('start', () => {
@@ -265,9 +345,14 @@ async function openSiteFromVoice(query) {
 
   try {
     if (chrome?.runtime?.sendMessage) {
-      const res = await chrome.runtime.sendMessage({ type: 'navable:openSite', query: q, newTab: false });
+      const res = await chrome.runtime.sendMessage({
+        type: 'navable:openSite',
+        query: q,
+        newTab: false,
+        outputLanguage: currentOutputLanguage()
+      });
       if (res?.ok) return;
-      setNewtabMicMessage(res?.error || 'Could not open that website.', 'assertive');
+      setNewtabMicMessage(res?.error || translate('open_site_failed'), 'assertive');
       return;
     }
   } catch (_err) {
@@ -276,21 +361,23 @@ async function openSiteFromVoice(query) {
 
   const url = resolveQueryToUrl(q);
   if (!url) {
-    setNewtabMicMessage('Missing website name or URL.', 'assertive');
+    setNewtabMicMessage(translate('missing_url'), 'assertive');
     return;
   }
   await openUrl(url);
 }
 
-async function handleNewtabTranscript(transcript) {
+async function handleNewtabTranscript(transcript, detectedLanguage) {
+  setNewtabOutputLanguage(transcript, detectedLanguage);
+  await ensureOutputLanguageReady();
   const cmd = parseVoiceCommand(transcript);
   if (!cmd) {
-    setNewtabMicMessage('I did not catch that. Try: “Open YouTube”.', 'polite');
+    setNewtabMicMessage(translate('newtab_try_open'), 'polite');
     return;
   }
 
   if (cmd.type === 'help') {
-    setNewtabMicMessage('Try: “Open YouTube”, “Open example dot com”, “Search for weather”.', 'assertive');
+    setNewtabMicMessage(translate('newtab_help_examples'), 'assertive');
     return;
   }
 
@@ -300,7 +387,7 @@ async function handleNewtabTranscript(transcript) {
   }
 
   if (cmd.type === 'open_site') {
-    setNewtabMicMessage(`Opening ${cmd.query}…`, 'assertive');
+    setNewtabMicMessage(translate('opening_site', { value: cmd.query }), 'assertive');
     await openSiteFromVoice(cmd.query);
   }
 }
@@ -314,12 +401,12 @@ async function startNewtabListening() {
     newtabWantsListening = false;
     newtabVoiceReady = true;
     refreshNewtabMicUi();
-    setNewtabMicMessage('Voice input is not available in this browser.', 'assertive');
+    setNewtabMicMessage(translate('voice_unavailable_browser'), 'assertive');
     return;
   }
 
   recognizer.start();
-  setNewtabMicMessage('Listening… Say “Open YouTube”.', 'polite');
+  setNewtabMicMessage(translate('newtab_listening'), 'polite');
 }
 
 function stopNewtabListening(opts = {}) {
@@ -330,7 +417,7 @@ function stopNewtabListening(opts = {}) {
   } catch (_err) {
     // ignore
   }
-  if (opts.announce) setNewtabMicMessage('Stopped listening.', 'polite');
+  if (opts.announce) setNewtabMicMessage(translate('stopped_listening'), 'polite');
 }
 
 async function toggleNewtabListening() {
@@ -386,7 +473,7 @@ function wireNewtabVoice() {
   if (!isVoiceSupported()) {
     const { btn: btn2 } = getVoiceStatusEls();
     if (btn2) btn2.disabled = true;
-    setNewtabMicMessage('Voice input is not available in this browser.', 'polite');
+    setNewtabMicMessage(translate('voice_unavailable_browser'), 'polite');
   }
 }
 

--- a/dist/src/options/index.html
+++ b/dist/src/options/index.html
@@ -24,7 +24,7 @@
               <div>
                 <h1 class="nv-options-title">Navable settings</h1>
                 <p class="nv-options-subtitle">
-                  Tune voice language, continuous listening, and AI summarization—without changing any of Navable’s core behavior.
+                  Tune voice fallback language, continuous listening, and AI features without changing Navable’s navigation behavior.
                 </p>
               </div>
             </div>
@@ -41,7 +41,7 @@
             <h2>Voice settings</h2>
             <div class="nv-form-grid">
               <div class="nv-field">
-                <label class="nv-label" for="language">Language</label>
+                <label class="nv-label" for="language">Fallback language</label>
                 <select id="language" class="nv-select">
                   <option value="en-US">English (United States)</option>
                   <option value="en-GB">English (United Kingdom)</option>
@@ -53,7 +53,7 @@
                 <span>Continuous listening (auto-start on pages)</span>
               </label>
             </div>
-            <p>Navable uses the browser’s built-in Web Speech API. Continuous listening may not be available on all sites.</p>
+            <p>Navable prefers backend multilingual transcription for automatic language detection, and falls back to the browser speech API if the backend is unavailable.</p>
           </div>
         </section>
 
@@ -85,7 +85,7 @@
                 <span>Do not summarize on sensitive sites</span>
               </label>
             </div>
-            <p>AI is only called when you explicitly run a “Summarize” command from the popup.</p>
+            <p>AI summaries are on-demand. Voice transcription may also use the backend when multilingual command recognition is available.</p>
           </div>
         </section>
 
@@ -110,8 +110,8 @@
             <h2>Privacy</h2>
             <p>
               Navable collects a structured snapshot of the current page (titles, headings, links, buttons, and non-sensitive form field
-              labels). It <strong>does not</strong> collect passwords, credit card fields, or raw audio. When AI summarization is enabled,
-              this snapshot may be sent to your configured backend for summarization, and only when you ask Navable to summarize the page.
+              labels). It <strong>does not</strong> collect passwords or credit card fields. Short microphone clips for spoken commands may
+              be sent to your configured backend for transcription, and page snapshots may be sent for summarization when those features are enabled.
             </p>
           </div>
         </section>

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   "content_scripts": [
     {
       "matches": ["https://*/*", "http://*/*"],
-      "js": ["src/common/announce.js", "src/common/speech.js", "src/content.js"],
+      "js": ["src/common/i18n.js", "src/common/announce.js", "src/common/speech.js", "src/content.js"],
       "run_at": "document_idle"
     }
   ],

--- a/src/background.js
+++ b/src/background.js
@@ -84,6 +84,150 @@ const NAVABLE_NEW_TAB_URL = (() => {
   }
 })();
 
+const TRANSLATE_MESSAGES_URL = 'http://localhost:3000/api/translate-messages';
+const OUTPUT_LOCALES = {
+  en: 'en-US',
+  fr: 'fr-FR',
+  ar: 'ar-SA'
+};
+const outputMessageLoadPromises = {};
+
+const OUTPUT_MESSAGES = {
+  en: {
+    summary_unavailable: 'Page summary is unavailable.',
+    no_title: 'No title found.',
+    title_value: 'Title: {value}.',
+    counts_value: 'Headings {headings}, links {links}, buttons {buttons}.',
+    top_heading: 'Top heading: {value}.',
+    excerpt_value: 'Page snippet: {value}.',
+    try_commands: 'Try commands like: describe this page, scroll down, read title, read heading.',
+    ai_summaries_off: 'AI summaries are off. Enable AI in options for a richer summary.',
+    suggestion_scroll: 'Try: scroll down.',
+    suggestion_title: 'Try: read the title.',
+    suggestion_heading: 'Try: move to the next heading.',
+    suggestion_open_link: 'Try: open first link.',
+    opening_value: 'Opening {value}.',
+    open_website_failed: 'Could not open that website.',
+    missing_url: 'Missing website name or URL.'
+  },
+  fr: {
+    summary_unavailable: 'Le resume de la page n est pas disponible.',
+    no_title: 'Aucun titre trouve.',
+    title_value: 'Titre : {value}.',
+    counts_value: 'Titres {headings}, liens {links}, boutons {buttons}.',
+    top_heading: 'Titre principal : {value}.',
+    excerpt_value: 'Extrait de la page : {value}.',
+    try_commands: 'Essayez des commandes comme : decris cette page, fais defiler vers le bas, lis le titre, lis le titre suivant.',
+    ai_summaries_off: 'Les resumes IA sont desactives. Activez l IA dans les options pour un resume plus riche.',
+    suggestion_scroll: 'Essayez : fais defiler vers le bas.',
+    suggestion_title: 'Essayez : lis le titre.',
+    suggestion_heading: 'Essayez : va au titre suivant.',
+    suggestion_open_link: 'Essayez : ouvre le premier lien.',
+    opening_value: 'Ouverture de {value}.',
+    open_website_failed: 'Impossible d ouvrir ce site.',
+    missing_url: 'Nom du site ou URL manquant.'
+  },
+  ar: {
+    summary_unavailable: 'ملخص الصفحة غير متاح.',
+    no_title: 'لم يتم العثور على عنوان.',
+    title_value: 'العنوان: {value}.',
+    counts_value: 'العناوين {headings}، الروابط {links}، الأزرار {buttons}.',
+    top_heading: 'أعلى عنوان: {value}.',
+    excerpt_value: 'مقتطف من الصفحة: {value}.',
+    try_commands: 'جرّب أوامر مثل: صف هذه الصفحة، مرر للأسفل، اقرأ العنوان، اقرأ العنوان التالي.',
+    ai_summaries_off: 'ملخصات الذكاء الاصطناعي متوقفة. فعّل الذكاء الاصطناعي من الإعدادات للحصول على ملخص أفضل.',
+    suggestion_scroll: 'جرّب: مرر إلى الأسفل.',
+    suggestion_title: 'جرّب: اقرأ العنوان.',
+    suggestion_heading: 'جرّب: انتقل إلى العنوان التالي.',
+    suggestion_open_link: 'جرّب: افتح أول رابط.',
+    opening_value: 'جارٍ فتح {value}.',
+    open_website_failed: 'تعذر فتح هذا الموقع.',
+    missing_url: 'اسم الموقع أو الرابط مفقود.'
+  }
+};
+
+function normalizeOutputLanguage(lang) {
+  const raw = String(lang || '').trim().replace(/_/g, '-');
+  if (!raw) return 'en';
+  try {
+    const canonical = new Intl.Locale(raw).baseName;
+    return canonical.split('-')[0].toLowerCase() || 'en';
+  } catch (_err) {
+    return raw.toLowerCase().split(/[-_]/)[0] || 'en';
+  }
+}
+
+function canonicalizeLocale(lang) {
+  const raw = String(lang || '').trim().replace(/_/g, '-');
+  if (!raw) return '';
+  try {
+    return new Intl.Locale(raw).baseName;
+  } catch (_err) {
+    const parts = raw.split('-').filter(Boolean);
+    if (!parts.length) return '';
+    parts[0] = parts[0].toLowerCase();
+    for (let i = 1; i < parts.length; i += 1) {
+      if (parts[i].length === 2) parts[i] = parts[i].toUpperCase();
+      else if (parts[i].length === 4) parts[i] = parts[i][0].toUpperCase() + parts[i].slice(1).toLowerCase();
+      else parts[i] = parts[i].toLowerCase();
+    }
+    return parts.join('-');
+  }
+}
+
+function sanitizeOutputMessages(candidate, fallbackDictionary) {
+  return Object.keys(fallbackDictionary).reduce((acc, key) => {
+    const value = candidate && Object.prototype.hasOwnProperty.call(candidate, key)
+      ? candidate[key]
+      : null;
+    acc[key] = typeof value === 'string' && value.trim() ? value : fallbackDictionary[key];
+    return acc;
+  }, {});
+}
+
+function ensureOutputMessages(lang) {
+  const normalized = normalizeOutputLanguage(lang);
+  if (!normalized || normalized === 'en' || OUTPUT_MESSAGES[normalized]) {
+    return Promise.resolve(OUTPUT_MESSAGES[normalized] || OUTPUT_MESSAGES.en);
+  }
+  if (outputMessageLoadPromises[normalized]) return outputMessageLoadPromises[normalized];
+
+  outputMessageLoadPromises[normalized] = fetch(TRANSLATE_MESSAGES_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      language: normalized,
+      messages: OUTPUT_MESSAGES.en
+    })
+  }).then((response) => {
+    if (!response.ok) throw new Error(`Translation failed with status ${response.status}`);
+    return response.json();
+  }).then((payload) => {
+    OUTPUT_MESSAGES[normalized] = sanitizeOutputMessages(payload?.messages, OUTPUT_MESSAGES.en);
+    return OUTPUT_MESSAGES[normalized];
+  }).catch(() => OUTPUT_MESSAGES.en).finally(() => {
+    delete outputMessageLoadPromises[normalized];
+  });
+
+  return outputMessageLoadPromises[normalized];
+}
+
+function outputLocale(lang) {
+  const normalized = normalizeOutputLanguage(lang);
+  if (OUTPUT_LOCALES[normalized]) return OUTPUT_LOCALES[normalized];
+  return canonicalizeLocale(lang) || normalized || OUTPUT_LOCALES.en;
+}
+
+function outputMessage(key, lang, params = {}) {
+  const normalized = normalizeOutputLanguage(lang);
+  const dictionary = OUTPUT_MESSAGES[normalized] || OUTPUT_MESSAGES.en;
+  const fallback = OUTPUT_MESSAGES.en;
+  const template = dictionary[key] || fallback[key] || key;
+  return String(template).replace(/\{(\w+)\}/g, (_match, name) => (
+    Object.prototype.hasOwnProperty.call(params, name) ? String(params[name]) : ''
+  ));
+}
+
 function isInternalNewTabUrl(url) {
   const u = String(url || '');
   if (!u) return false;
@@ -130,30 +274,182 @@ async function tryExecutePlan(plan) {
   return false;
 }
 
-function stubPlanner(command, structure) {
+const INTENT_STOPWORDS = new Set([
+  'a', 'an', 'the', 'me', 'to', 'for', 'please', 'can', 'could', 'would', 'you',
+  'show', 'take', 'bring', 'go', 'move', 'open', 'visit', 'launch', 'scroll', 'read',
+  'tell', 'what', 'is', 'my', 'current', 'this', 'that', 'of', 'on', 'in', 'at',
+  'page', 'section', 'heading', 'link', 'button', 'item', 'tab', 'website', 'site',
+  'le', 'la', 'les', 'de', 'des', 'du', 'un', 'une', 'moi', 'mon', 'ma', 'mes', 'sur',
+  'ici', 'cette', 'ce', 'cet', 'dans', 'pour', 'que', 'quoi', 'ou', 'où', 'vas', 'va',
+  'ouvre', 'lis', 'montre', 'titre', 'lien', 'bouton', 'champ',
+  'من', 'على', 'في', 'إلى', 'الى', 'هذا', 'هذه', 'ذلك', 'تلك', 'لي', 'لو', 'ممكن',
+  'افتح', 'اذهب', 'روح', 'انتقل', 'اقرأ', 'مرر', 'انزل', 'اطلع', 'العنوان', 'الرابط',
+  'الزر', 'الصفحة', 'القسم', 'التالي', 'السابق'
+]);
+
+function hasIntent(text, patterns) {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function tokenizeIntentText(text) {
+  return String(text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\u0600-\u06ff\s]/g, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token && token.length > 1 && !INTENT_STOPWORDS.has(token));
+}
+
+function scoreIntentLabel(label, tokens) {
+  const lower = String(label || '').toLowerCase();
+  if (!lower || !tokens.length) return 0;
+  let score = 0;
+  for (const token of tokens) {
+    if (lower === token) score += 5;
+    else if (lower.startsWith(token) || lower.endsWith(token)) score += 3;
+    else if (lower.includes(token)) score += token.length >= 5 ? 2 : 1;
+  }
+  return score;
+}
+
+function collectIntentCandidates(structure, targetTypes) {
+  const candidates = [];
+  const targets = Array.isArray(targetTypes) && targetTypes.length ? targetTypes : ['link', 'button', 'heading', 'input'];
+  for (const target of targets) {
+    if (target === 'link' && structure && Array.isArray(structure.links)) {
+      structure.links.forEach((item) => candidates.push({ target: 'link', label: item?.label || '' }));
+    }
+    if (target === 'button' && structure && Array.isArray(structure.buttons)) {
+      structure.buttons.forEach((item) => candidates.push({ target: 'button', label: item?.label || '' }));
+    }
+    if (target === 'heading' && structure && Array.isArray(structure.headings)) {
+      structure.headings.forEach((item) => candidates.push({ target: 'heading', label: item?.label || '' }));
+    }
+    if (target === 'input' && structure && Array.isArray(structure.inputs)) {
+      structure.inputs.forEach((item) => candidates.push({ target: 'input', label: item?.label || '' }));
+    }
+  }
+  return candidates;
+}
+
+function chooseIntentTarget(text, structure) {
+  const normalized = String(text || '').toLowerCase();
+  const tokens = tokenizeIntentText(normalized);
+  if (!tokens.length || !structure) return null;
+
+  let targetTypes = ['link', 'button', 'heading', 'input'];
+  if (/\b(button|press|tap|activate|bouton)\b|زر/.test(normalized)) targetTypes = ['button', 'link'];
+  else if (/\b(link|open|visit|launch|website|site|lien|ouvre|visite)\b|رابط|افتح/.test(normalized)) targetTypes = ['link', 'heading', 'button'];
+  else if (/\b(section|heading|part|titre)\b|عنوان|قسم/.test(normalized)) targetTypes = ['heading', 'link'];
+  else if (/\b(field|input|box|search|champ)\b|حقل|بحث/.test(normalized)) targetTypes = ['input', 'button', 'link'];
+
+  const candidates = collectIntentCandidates(structure, targetTypes);
+  let best = null;
+  for (const candidate of candidates) {
+    const score = scoreIntentLabel(candidate.label, tokens);
+    if (!score) continue;
+    if (!best || score > best.score) best = { ...candidate, score };
+  }
+  return best;
+}
+
+function stubPlanner(command, structure, outputLanguage, preferIntentFallback) {
   const text = String(command || '').toLowerCase();
   const steps = [];
   let description = '';
-  const orientation = buildFriendlyOrientation(structure);
+  const orientation = buildFriendlyOrientation(structure, outputLanguage);
+  let matched = false;
 
-  if (text.includes('describe') || text.includes('summarize') || text.includes('summary')) {
+  if (
+    text.includes('describe') ||
+    text.includes('summarize') ||
+    text.includes('summary') ||
+    text.includes('overview') ||
+    text.includes('where am i') ||
+    text.includes('what can i do here') ||
+    /\br[ée]sum[ée]?\b/.test(text) ||
+    /\bd[ée]cri(s|re)\b/.test(text) ||
+    /où suis[- ]?je|ou suis[- ]?je/.test(text) ||
+    /que puis[- ]je faire ici/.test(text) ||
+    /لخص هذه الصفحة|صف هذه الصفحة|أين أنا|اين انا|ماذا يمكنني أن أفعل هنا|ماذا يمكنني ان افعل هنا/.test(text)
+  ) {
     description = orientation;
-  } else if (text.includes('scroll up')) {
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bscroll up\b/, /\bgo up\b/, /\bmove up\b/, /\bback up\b/, /\bup a bit\b/, /\bhigher\b/,
+    /\bmonte\b/, /\bplus haut\b/, /\bfais d[ée]filer vers le haut\b/,
+    /اطلع|اصعد|مرر.*(للأعلى|للاعلى)|فوق/
+  ])) {
     steps.push({ action: 'scroll', direction: 'up' });
-  } else if (text.includes('scroll')) {
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bscroll\b/, /\bgo down\b/, /\bmove down\b/, /\blower\b/, /\bdown a bit\b/, /\bshow me more\b/, /\bkeep going\b/,
+    /\bdescend(s)?\b/, /\bplus bas\b/, /\bfais d[ée]filer vers le bas\b/,
+    /انزل|نز[ّل]|\bمرر.*(للأسفل|للاسفل)\b|تحت/
+  ])) {
     steps.push({ action: 'scroll', direction: 'down' });
-  } else if (text.includes('read title')) {
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bread title\b/, /\bpage title\b/, /\bwhat('?s| is) the title\b/, /\btell me the title\b/,
+    /\blis le titre\b/, /\bquel est le titre\b/,
+    /اقر[أا] العنوان|ما عنوان الصفحة|ما هو عنوان الصفحة/
+  ])) {
     steps.push({ action: 'read_title' });
-  } else if (text.includes('read selection')) {
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bread selection\b/, /\bread selected\b/, /\bwhat did i select\b/,
+    /\blis la s[ée]lection\b/,
+    /اقر[أا] التحديد|ما الذي حددته/
+  ])) {
     steps.push({ action: 'read_selection' });
-  } else if (text.includes('read heading')) {
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bread heading\b/, /\bcurrent heading\b/, /\bwhat heading am i on\b/,
+    /\blis le titre\b/, /\bquel titre\b/, /\bsection actuelle\b/,
+    /اقر[أا] العنوان|ما العنوان الحالي|ما القسم الحالي/
+  ])) {
     steps.push({ action: 'read_heading', n: 1 });
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bwhat('?s| is) focused\b/, /\bwhat am i on\b/, /\bread current\b/, /\bread focused\b/,
+    /\bsur quoi suis[- ]je\b/, /\blis l[' ]?[ée]l[ée]ment courant\b/,
+    /ما العنصر المحدد|على ماذا انا|ما أنا عليه|ما انا عليه/
+  ])) {
+    steps.push({ action: 'read_focused' });
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bnext heading\b/, /\bnext section\b/, /\bnext part\b/, /\bmove forward a section\b/,
+    /\btitre suivant\b/, /\bsection suivante\b/,
+    /العنوان التالي|القسم التالي/
+  ])) {
+    steps.push({ action: 'move_heading', direction: 'next' });
+    matched = true;
+  } else if (hasIntent(text, [
+    /\bprevious heading\b/, /\bprev heading\b/, /\bprevious section\b/, /\bgo back a section\b/, /\blast section\b/,
+    /\btitre pr[ée]c[ée]dent\b/, /\bsection pr[ée]c[ée]dente\b/,
+    /العنوان السابق|القسم السابق/
+  ])) {
+    steps.push({ action: 'move_heading', direction: 'prev' });
+    matched = true;
   } else {
-    // fallback guidance
-    description = 'Try commands like: describe this page, scroll down, read title, read heading.';
+    const target = chooseIntentTarget(text, structure);
+    if (target) {
+      matched = true;
+      if (target.target === 'heading') {
+        steps.push({ action: 'focus_element', target: 'heading', label: target.label });
+      } else if (/\bfocus\b/.test(text)) {
+        steps.push({ action: 'focus_element', target: target.target, label: target.label });
+      } else if (target.target === 'input') {
+        steps.push({ action: 'focus_element', target: 'input', label: target.label });
+      } else {
+        steps.push({ action: 'click_element', target: target.target, label: target.label });
+      }
+    } else if (!preferIntentFallback) {
+      description = outputMessage('try_commands', outputLanguage);
+    }
   }
 
-  return { description, steps };
+  return { description, steps, matched };
 }
 
 function isSummaryCommandText(text) {
@@ -168,6 +464,10 @@ function isSummaryCommandText(text) {
     t.includes("what's on this page") ||
     t.includes('what is on this page') ||
     t.includes("what's this page") ||
+    /r[ée]sum[ée]?.*cette page/.test(t) ||
+    /d[ée]cri(s|re).*cette page/.test(t) ||
+    /c[' ]?est quoi cette page/.test(t) ||
+    /qu[' ]?est[- ]ce que cette page/.test(t) ||
     /ما هذه الصفحه/.test(t) ||
     /ما هذه الصفحة/.test(t) ||
     /ما هو محتوى الصفحة/.test(t) ||
@@ -176,18 +476,28 @@ function isSummaryCommandText(text) {
   );
 }
 
-function buildFriendlyOrientation(structure) {
-  if (!structure) return 'Page summary is unavailable.';
+function buildFriendlyOrientation(structure, outputLanguage) {
+  if (!structure) return outputMessage('summary_unavailable', outputLanguage);
   const counts = structure.counts || {};
-  const title = structure.title ? `Title: ${structure.title}.` : 'No title found.';
-  const basics = `Headings ${counts.headings || 0}, links ${counts.links || 0}, buttons ${counts.buttons || 0}.`;
+  const title = structure.title
+    ? outputMessage('title_value', outputLanguage, { value: structure.title })
+    : outputMessage('no_title', outputLanguage);
+  const basics = outputMessage('counts_value', outputLanguage, {
+    headings: counts.headings || 0,
+    links: counts.links || 0,
+    buttons: counts.buttons || 0
+  });
   const topHeading =
-    structure.headings && structure.headings.length ? `Top heading: ${structure.headings[0].label}.` : '';
-  const excerpt = structure.excerpt ? `Page snippet: ${structure.excerpt.slice(0, 220)}.` : '';
+    structure.headings && structure.headings.length
+      ? outputMessage('top_heading', outputLanguage, { value: structure.headings[0].label })
+      : '';
+  const excerpt = structure.excerpt
+    ? outputMessage('excerpt_value', outputLanguage, { value: structure.excerpt.slice(0, 220) })
+    : '';
   return [title, basics, topHeading, excerpt].filter(Boolean).join(' ');
 }
 
-const summaryCache = { url: null, ts: 0, result: null };
+const summaryCache = { url: null, outputLanguage: 'en', ts: 0, result: null };
 
 async function loadSettings() {
   return new Promise((resolve) => {
@@ -201,7 +511,10 @@ async function loadSettings() {
   });
 }
 
-async function runPlanner(command) {
+async function runPlanner(command, requestedOutputLanguage, preferIntentFallback) {
+  const settings = await loadSettings();
+  const outputLanguage = normalizeOutputLanguage(requestedOutputLanguage || settings.language || 'en-US');
+  await ensureOutputMessages(outputLanguage);
   const structureRes = await sendToActiveTab({ type: 'navable:getStructure' });
   const structure = structureRes && structureRes.structure ? structureRes.structure : null;
   const text = String(command || '').toLowerCase();
@@ -209,7 +522,6 @@ async function runPlanner(command) {
 
   // If the user asks to summarize/summary, prefer backend AI + plan where allowed by settings.
   if (isSummaryRequest) {
-    const settings = await loadSettings();
     const aiEnabled = !!settings.aiEnabled;
     const aiMode = settings.aiMode || 'off';
     const canUseCache =
@@ -217,6 +529,7 @@ async function runPlanner(command) {
       structure &&
       structure.url &&
       summaryCache.url === structure.url &&
+      summaryCache.outputLanguage === outputLanguage &&
       Date.now() - summaryCache.ts < 2 * 60 * 1000;
 
     if (aiEnabled && aiMode !== 'off') {
@@ -227,7 +540,8 @@ async function runPlanner(command) {
             type: 'navable:announce',
             text: cached.description,
             mode: 'assertive',
-            priority: true
+            priority: true,
+            lang: outputLocale(outputLanguage)
           });
         }
         if (aiMode === 'summary_plan' && cached.plan && cached.plan.steps && cached.plan.steps.length) {
@@ -246,7 +560,8 @@ async function runPlanner(command) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             command: command || 'Summarize this page',
-            pageStructure: structure
+            pageStructure: structure,
+            outputLanguage
           })
         });
         if (response.ok) {
@@ -274,7 +589,8 @@ async function runPlanner(command) {
             type: 'navable:announce',
             text: description,
             mode: 'assertive',
-            priority: true
+            priority: true,
+            lang: outputLocale(outputLanguage)
           });
         }
         if (aiMode === 'summary_plan' && aiResult.plan && aiResult.plan.steps && aiResult.plan.steps.length) {
@@ -293,6 +609,7 @@ async function runPlanner(command) {
           suggestions: aiResult.suggestions
         };
         summaryCache.url = structure && structure.url ? structure.url : null;
+        summaryCache.outputLanguage = outputLanguage;
         summaryCache.ts = Date.now();
         summaryCache.result = result;
         return result;
@@ -300,8 +617,14 @@ async function runPlanner(command) {
       // If AI path fails, fall back to local stub planner.
     } else {
       // AI disabled: give a friendly orientation and tell the user how to enable AI.
-      const description = `${buildFriendlyOrientation(structure)} AI summaries are off. Enable AI in options for a richer summary.`;
-      await sendToActiveTab({ type: 'navable:announce', text: description, mode: 'assertive', priority: true });
+      const description = `${buildFriendlyOrientation(structure, outputLanguage)} ${outputMessage('ai_summaries_off', outputLanguage)}`;
+      await sendToActiveTab({
+        type: 'navable:announce',
+        text: description,
+        mode: 'assertive',
+        priority: true,
+        lang: outputLocale(outputLanguage)
+      });
       return {
         ok: true,
         plan: { steps: [] },
@@ -313,14 +636,19 @@ async function runPlanner(command) {
     }
   }
 
-  const plan = stubPlanner(command, structure);
+  const plan = stubPlanner(command, structure, outputLanguage, !!preferIntentFallback);
+
+  if (preferIntentFallback && !plan.matched && !plan.description && (!plan.steps || !plan.steps.length)) {
+    return { ok: false, error: 'Intent not understood', unhandled: true, plan: { steps: [] }, structure };
+  }
 
   if (plan.description) {
     await sendToActiveTab({
       type: 'navable:announce',
       text: plan.description,
       mode: isSummaryRequest ? 'assertive' : 'polite',
-      priority: isSummaryRequest
+      priority: isSummaryRequest,
+      lang: outputLocale(outputLanguage)
     });
   }
   if (plan.steps && plan.steps.length) {
@@ -347,6 +675,125 @@ function normalizeSpokenUrl(query) {
   out = out.replace(/\s*\.\s*/g, '.');
   out = out.replace(/\s*:\s*/g, ':');
   return out.trim();
+}
+
+const KNOWN_SITE_ALIASES = {
+  youtube: 'https://www.youtube.com/',
+  'you tube': 'https://www.youtube.com/',
+  'يوتيوب': 'https://www.youtube.com/',
+  'اليوتيوب': 'https://www.youtube.com/',
+  google: 'https://www.google.com/',
+  'جوجل': 'https://www.google.com/',
+  'غوغل': 'https://www.google.com/',
+  gmail: 'https://mail.google.com/',
+  'google mail': 'https://mail.google.com/',
+  'جي ميل': 'https://mail.google.com/',
+  'جيميل': 'https://mail.google.com/',
+  facebook: 'https://www.facebook.com/',
+  'فيسبوك': 'https://www.facebook.com/',
+  'فيس بوك': 'https://www.facebook.com/',
+  instagram: 'https://www.instagram.com/',
+  'انستغرام': 'https://www.instagram.com/',
+  'انستجرام': 'https://www.instagram.com/',
+  whatsapp: 'https://web.whatsapp.com/',
+  'واتساب': 'https://web.whatsapp.com/',
+  twitter: 'https://x.com/',
+  x: 'https://x.com/',
+  'تويتر': 'https://x.com/',
+  'تيكتوك': 'https://www.tiktok.com/',
+  'تيك توك': 'https://www.tiktok.com/',
+  tiktok: 'https://www.tiktok.com/',
+  linkedin: 'https://www.linkedin.com/',
+  'لينكدان': 'https://www.linkedin.com/',
+  reddit: 'https://www.reddit.com/',
+  'ريديت': 'https://www.reddit.com/',
+  wikipedia: 'https://www.wikipedia.org/',
+  'ويكيبيديا': 'https://www.wikipedia.org/',
+  amazon: 'https://www.amazon.com/',
+  'امازون': 'https://www.amazon.com/',
+  amazonprime: 'https://www.amazon.com/',
+  netflix: 'https://www.netflix.com/',
+  'نتفليكس': 'https://www.netflix.com/',
+  spotify: 'https://open.spotify.com/',
+  'سبوتيفاي': 'https://open.spotify.com/',
+  github: 'https://github.com/',
+  'جيتهاب': 'https://github.com/',
+  'جيت هب': 'https://github.com/',
+  'stack overflow': 'https://stackoverflow.com/',
+  stackoverflow: 'https://stackoverflow.com/',
+  'chat gpt': 'https://chatgpt.com/',
+  chatgpt: 'https://chatgpt.com/',
+  'شات جي بي تي': 'https://chatgpt.com/',
+  'تشات جي بي تي': 'https://chatgpt.com/'
+};
+
+function normalizeNamedSiteQuery(query) {
+  let s = normalizeSpokenUrl(query);
+  if (!s) return '';
+  s = s
+    .replace(/^(the|a|an)\s+/g, '')
+    .replace(/^(site|website|page|app)\s+/g, '')
+    .replace(/^(le|la|les|un|une)\s+/g, '')
+    .replace(/^(site\s+web|site|page|application|appli|onglet)\s+/g, '')
+    .replace(/^(موقع|الموقع|صفحة|الصفحة|تطبيق|التطبيق)\s+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return s;
+}
+
+function resolveNamedSiteUrl(query) {
+  const normalized = normalizeNamedSiteQuery(query);
+  if (!normalized) return null;
+  if (KNOWN_SITE_ALIASES[normalized]) return KNOWN_SITE_ALIASES[normalized];
+
+  const withoutArticle = normalized
+    .replace(/^(the|le|la|les)\s+/g, '')
+    .replace(/^ال/g, '')
+    .trim();
+  if (KNOWN_SITE_ALIASES[withoutArticle]) return KNOWN_SITE_ALIASES[withoutArticle];
+
+  const squeezed = withoutArticle.replace(/\s+/g, '');
+  if (KNOWN_SITE_ALIASES[squeezed]) return KNOWN_SITE_ALIASES[squeezed];
+
+  return null;
+}
+
+function stripDiacritics(value) {
+  const text = String(value || '');
+  if (!text) return '';
+  try {
+    return text.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+  } catch (_e) {
+    return text;
+  }
+}
+
+function guessDirectHostUrl(query) {
+  const normalized = normalizeNamedSiteQuery(query);
+  if (!normalized) return null;
+  if (Array.from(normalized).some((ch) => ch.charCodeAt(0) > 127)) return null;
+
+  const ascii = stripDiacritics(normalized)
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!ascii) return null;
+
+  const tokens = ascii.split(' ').filter(Boolean);
+  if (!tokens.length) return null;
+
+  const joined = tokens.join('');
+  if (!/^[a-z0-9-]+$/.test(joined)) return null;
+  if (joined.length < 2) return `https://${joined}.com/`;
+  return `https://www.${joined}.com/`;
+}
+
+function resolveDirectOpenFallbackUrl(query) {
+  const directGuess = guessDirectHostUrl(query);
+  if (directGuess) return directGuess;
+  return `https://www.google.com/search?btnI=I&q=${encodeURIComponent(`${String(query || '').trim()} official site`)}`;
 }
 
 function tryParseHttpUrl(candidate) {
@@ -392,6 +839,9 @@ function resolveOpenQueryToUrl(query) {
   const direct = tryParseHttpUrl(normalized);
   if (direct) return direct;
 
+  const namedSite = resolveNamedSiteUrl(raw);
+  if (namedSite) return namedSite;
+
   // Domain (with optional path), missing scheme
   if (looksLikeHostWithOptionalPath(normalized)) {
     return tryParseHttpUrl(`https://${normalized}`);
@@ -402,8 +852,8 @@ function resolveOpenQueryToUrl(query) {
     return `https://www.${normalized}.com/`;
   }
 
-  // Fallback to search (works for any phrase)
-  return `https://www.google.com/search?q=${encodeURIComponent(raw)}`;
+  // Open-intent fallback: prefer direct-open behavior over a search-results page.
+  return resolveDirectOpenFallbackUrl(raw);
 }
 
 function friendlyUrlForSpeech(url) {
@@ -417,15 +867,18 @@ function friendlyUrlForSpeech(url) {
   }
 }
 
-async function openSiteInBrowser(query, newTab) {
+async function openSiteInBrowser(query, newTab, requestedOutputLanguage) {
+  const outputLanguage = normalizeOutputLanguage(requestedOutputLanguage);
+  await ensureOutputMessages(outputLanguage);
   const url = resolveOpenQueryToUrl(query);
-  if (!url) return { ok: false, error: 'Missing website name or URL.' };
+  if (!url) return { ok: false, error: outputMessage('missing_url', outputLanguage) };
 
   try {
     await sendToActiveTab({
       type: 'navable:announce',
-      text: `Opening ${friendlyUrlForSpeech(url)}.`,
-      mode: 'assertive'
+      text: outputMessage('opening_value', outputLanguage, { value: friendlyUrlForSpeech(url) }),
+      mode: 'assertive',
+      lang: outputLocale(outputLanguage)
     });
   } catch (_e) {
     // ignore announce failures (e.g., unsupported active tab)
@@ -445,7 +898,7 @@ async function openSiteInBrowser(query, newTab) {
     return { ok: true, url };
   } catch (err) {
     console.warn('[Navable] openSite failed', err);
-    return { ok: false, error: 'Could not open that website.' };
+    return { ok: false, error: outputMessage('open_website_failed', outputLanguage) };
   }
 }
 
@@ -510,7 +963,7 @@ try {
 // Planner + bus bridge
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg && msg.type === 'navable:openSite') {
-    openSiteInBrowser(msg.query || '', msg.newTab).then((res) => {
+    openSiteInBrowser(msg.query || '', msg.newTab, msg.outputLanguage).then((res) => {
       sendResponse(res);
     }).catch((err) => {
       sendResponse({ ok: false, error: String(err || 'open site failed') });
@@ -518,7 +971,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     return true;
   }
   if (msg && msg.type === 'planner:run') {
-    runPlanner(msg.command || '').then((res) => {
+    runPlanner(msg.command || '', msg.outputLanguage, msg.preferIntentFallback).then((res) => {
       sendResponse(res);
     }).catch((err) => {
       sendResponse({ ok: false, error: String(err || 'planner failed') });
@@ -527,7 +980,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
   if (msg && msg.type === 'bus:request') {
     if (msg.kind === 'planner:run') {
-      runPlanner(msg.payload?.command || '').then((res) => sendResponse(res)).catch((err) => {
+      runPlanner(msg.payload?.command || '', msg.payload?.outputLanguage, msg.payload?.preferIntentFallback).then((res) => sendResponse(res)).catch((err) => {
         sendResponse({ ok: false, error: String(err || 'planner failed') });
       });
       return true;

--- a/src/common/announce.js
+++ b/src/common/announce.js
@@ -202,7 +202,14 @@
     return panel;
   }
 
-  function showPriorityOutput(text) {
+  function applyLanguageAttributes(node, opts) {
+    if (!node) return;
+    const lang = opts && opts.lang ? String(opts.lang).trim() : '';
+    if (lang) node.setAttribute('lang', lang);
+    else node.removeAttribute('lang');
+  }
+
+  function showPriorityOutput(text, opts) {
     const panel = ensurePriorityPanel();
     if (!panel) return;
     const textarea = document.getElementById('navable-output-text');
@@ -224,6 +231,8 @@
     panel.style.display = 'block';
     emitOutputOpen(true);
     textarea.value = message;
+    applyLanguageAttributes(panel, opts);
+    applyLanguageAttributes(textarea, opts);
 
     // Put the screen reader/keyboard cursor directly on the output text and select it.
     setTimeout(() => {
@@ -239,6 +248,7 @@
   function setAnnounceText(region, mode, text, opts) {
     const m = mode === 'assertive' ? 'assertive' : 'polite';
     const shouldFocus = !!(opts && opts.focus === true);
+    applyLanguageAttributes(region, opts);
 
     // A clear-then-set with small delays is more reliably announced by VoiceOver and NVDA.
     if (timersByMode[m]) {
@@ -270,8 +280,8 @@
       const region = ensureLiveRegion(mode);
       setAnnounceText(region, mode, text, opts);
     },
-    output(text) {
-      showPriorityOutput(text);
+    output(text, opts) {
+      showPriorityOutput(text, opts);
     }
   };
 })();

--- a/src/common/i18n.js
+++ b/src/common/i18n.js
@@ -1,0 +1,380 @@
+(function () {
+  if (typeof window === 'undefined' || window.NavableI18n) return;
+
+  var DEFAULT_LANGUAGE = 'en';
+  var DEFAULT_TRANSLATE_URL = 'http://localhost:3000/api/translate-messages';
+  var LOCALES = {
+    en: 'en-US',
+    fr: 'fr-FR',
+    ar: 'ar-SA'
+  };
+
+  var LANGUAGE_NAMES = {
+    english: 'en',
+    anglais: 'en',
+    eng: 'en',
+    french: 'fr',
+    francais: 'fr',
+    français: 'fr',
+    arabe: 'ar',
+    arabic: 'ar',
+    arabee: 'ar',
+    العربية: 'ar',
+    الانجليزية: 'en',
+    الإنجليزية: 'en',
+    الفرنسية: 'fr'
+  };
+
+  var MESSAGES = {
+    en: {
+      navable_ready: 'Navable is ready. Say "help" to hear example commands.',
+      navable_test_announcement: 'Navable: test announcement (fallback hotkey).',
+      generic_announcement: 'Navable: announcement.',
+      help_examples:
+        'Try: summarize this page, scroll down, read title, next heading, open first link, activate focused, read selection. Press Alt+Shift+M to toggle listening.',
+      listening_help: 'Listening. Say "help" to hear example commands.',
+      stopped_listening: 'Stopped listening. Press Alt+Shift+M to start again.',
+      unknown_command: 'I did not catch that. Say "help" to hear example commands.',
+      speech_not_available: 'Speech recognition not available.',
+      speech_not_allowed: 'Speech recognition is not allowed in this browser.',
+      speech_network_issue: 'Speech recognition is unavailable due to a network issue.',
+      speech_problem_retry: 'Speech recognition had a problem. Please try again.',
+      microphone_busy_retry: 'Microphone is busy in another tab or app. Retrying...',
+      scrolled_down: 'Scrolled down.',
+      scrolled_up: 'Scrolled up.',
+      scrolled_top: 'Scrolled to top.',
+      scrolled_bottom: 'Scrolled to bottom.',
+      title_value: 'Title: {value}',
+      value_not_found: 'not found',
+      selection_value: 'Selection: {value}',
+      no_selection: 'No selection.',
+      no_focused_text: 'No focused element text.',
+      no_focused_element: 'No focused element.',
+      not_found_heading: 'I did not find that heading.',
+      not_found_link: 'I did not find that link.',
+      not_found_button: 'I did not find that button.',
+      not_found_generic: 'I did not find a {target}.',
+      heading_value: 'Heading: {value}',
+      unnamed: 'unnamed',
+      opening_value: 'Opening {value}',
+      focused_value: 'Focused {value}',
+      activated_value: 'Activated {value}',
+      target_link: 'link',
+      target_button: 'button',
+      target_heading: 'heading',
+      target_input: 'input',
+      target_element: 'element',
+      summarizing_wait: 'Summarizing this page... please wait.',
+      summarize_unavailable_page: 'Sorry, summarization is unavailable on this page.',
+      summarize_failed: 'Sorry, I could not summarize this page.',
+      summarize_request_failed: 'Sorry, the summary request failed. Please try again.',
+      tell_website_to_open: 'Tell me which website to open.',
+      open_site_unavailable: 'Opening a website is unavailable.',
+      open_site_failed: 'Could not open that site.',
+      wait_for_user_input: 'Please provide input, then tell me to continue.',
+      newtab_try_open: 'I did not catch that. Try: "Open YouTube".',
+      newtab_help_examples: 'Try: "Open YouTube", "Open example dot com", "Search for weather".',
+      newtab_listening: 'Listening... Say "Open YouTube".',
+      voice_unavailable_browser: 'Voice input is not available in this browser.',
+      mic_access_blocked: 'Microphone access is blocked. Allow microphone for this extension to use voice.',
+      mic_busy: 'Microphone is busy. Close other apps or tabs using the mic, then try again.',
+      opening_site: 'Opening {value}...',
+      missing_url: 'Missing website name or URL.'
+    },
+    fr: {
+      navable_ready: 'Navable est pret. Dites "aide" pour entendre des exemples de commandes.',
+      navable_test_announcement: 'Navable : annonce de test (raccourci de secours).',
+      generic_announcement: 'Navable : annonce.',
+      help_examples:
+        'Essayez : resume cette page, fais defiler vers le bas, lis le titre, titre suivant, ouvre le premier lien, active l element cible, lis la selection. Appuyez sur Alt+Shift+M pour activer ou arreter l ecoute.',
+      listening_help: 'J ecoute. Dites "aide" pour entendre des exemples de commandes.',
+      stopped_listening: 'Ecoute arretee. Appuyez sur Alt+Shift+M pour recommencer.',
+      unknown_command: 'Je n ai pas compris. Dites "aide" pour entendre des exemples de commandes.',
+      speech_not_available: 'La reconnaissance vocale n est pas disponible.',
+      speech_not_allowed: 'La reconnaissance vocale n est pas autorisee dans ce navigateur.',
+      speech_network_issue: 'La reconnaissance vocale est indisponible a cause d un probleme reseau.',
+      speech_problem_retry: 'La reconnaissance vocale a rencontre un probleme. Reessayez.',
+      microphone_busy_retry: 'Le microphone est utilise dans un autre onglet ou une autre application. Nouvelle tentative...',
+      scrolled_down: 'Defilement vers le bas.',
+      scrolled_up: 'Defilement vers le haut.',
+      scrolled_top: 'Retour en haut de la page.',
+      scrolled_bottom: 'Aller en bas de la page.',
+      title_value: 'Titre : {value}',
+      value_not_found: 'introuvable',
+      selection_value: 'Selection : {value}',
+      no_selection: 'Aucune selection.',
+      no_focused_text: 'Aucun texte sur l element cible.',
+      no_focused_element: 'Aucun element cible.',
+      not_found_heading: 'Je n ai pas trouve ce titre.',
+      not_found_link: 'Je n ai pas trouve ce lien.',
+      not_found_button: 'Je n ai pas trouve ce bouton.',
+      not_found_generic: 'Je n ai pas trouve {target}.',
+      heading_value: 'Titre : {value}',
+      unnamed: 'sans nom',
+      opening_value: 'Ouverture de {value}',
+      focused_value: 'Focus sur {value}',
+      activated_value: 'Activation de {value}',
+      target_link: 'le lien',
+      target_button: 'le bouton',
+      target_heading: 'le titre',
+      target_input: 'le champ',
+      target_element: 'l element',
+      summarizing_wait: 'Je resume cette page... veuillez patienter.',
+      summarize_unavailable_page: 'Desole, le resume n est pas disponible sur cette page.',
+      summarize_failed: 'Desole, je n ai pas pu resumer cette page.',
+      summarize_request_failed: 'Desole, la demande de resume a echoue. Reessayez.',
+      tell_website_to_open: 'Dites-moi quel site ouvrir.',
+      open_site_unavailable: 'L ouverture d un site web n est pas disponible.',
+      open_site_failed: 'Impossible d ouvrir ce site.',
+      wait_for_user_input: 'Veuillez fournir une saisie, puis dites-moi de continuer.',
+      newtab_try_open: 'Je n ai pas compris. Essayez : "Ouvre YouTube".',
+      newtab_help_examples: 'Essayez : "Ouvre YouTube", "Ouvre example point com", "Recherche la meteo".',
+      newtab_listening: 'J ecoute... Dites "Ouvre YouTube".',
+      voice_unavailable_browser: 'La saisie vocale n est pas disponible dans ce navigateur.',
+      mic_access_blocked: 'L acces au microphone est bloque. Autorisez le microphone pour cette extension.',
+      mic_busy: 'Le microphone est occupe. Fermez les autres applications ou onglets qui l utilisent, puis reessayez.',
+      opening_site: 'Ouverture de {value}...',
+      missing_url: 'Nom du site ou URL manquant.'
+    },
+    ar: {
+      navable_ready: 'نافابل جاهز. قل "مساعدة" لسماع أمثلة للأوامر.',
+      navable_test_announcement: 'نافابل: إعلان تجريبي (اختصار احتياطي).',
+      generic_announcement: 'نافابل: إعلان.',
+      help_examples:
+        'جرّب: لخّص هذه الصفحة، مرر إلى الأسفل، اقرأ العنوان، العنوان التالي، افتح أول رابط، فعّل العنصر المحدد، اقرأ التحديد. اضغط Alt+Shift+M لتبديل الاستماع.',
+      listening_help: 'أستمع الآن. قل "مساعدة" لسماع أمثلة للأوامر.',
+      stopped_listening: 'تم إيقاف الاستماع. اضغط Alt+Shift+M للبدء من جديد.',
+      unknown_command: 'لم أفهم ذلك. قل "مساعدة" لسماع أمثلة للأوامر.',
+      speech_not_available: 'التعرّف على الكلام غير متاح.',
+      speech_not_allowed: 'التعرّف على الكلام غير مسموح به في هذا المتصفح.',
+      speech_network_issue: 'التعرّف على الكلام غير متاح بسبب مشكلة في الشبكة.',
+      speech_problem_retry: 'حدثت مشكلة في التعرّف على الكلام. حاول مرة أخرى.',
+      microphone_busy_retry: 'الميكروفون مستخدم في تبويب أو تطبيق آخر. سأحاول مرة أخرى...',
+      scrolled_down: 'تم التمرير إلى الأسفل.',
+      scrolled_up: 'تم التمرير إلى الأعلى.',
+      scrolled_top: 'تم الانتقال إلى أعلى الصفحة.',
+      scrolled_bottom: 'تم الانتقال إلى أسفل الصفحة.',
+      title_value: 'العنوان: {value}',
+      value_not_found: 'غير موجود',
+      selection_value: 'التحديد: {value}',
+      no_selection: 'لا يوجد تحديد.',
+      no_focused_text: 'لا يوجد نص للعنصر المحدد.',
+      no_focused_element: 'لا يوجد عنصر محدد.',
+      not_found_heading: 'لم أجد هذا العنوان.',
+      not_found_link: 'لم أجد هذا الرابط.',
+      not_found_button: 'لم أجد هذا الزر.',
+      not_found_generic: 'لم أجد {target}.',
+      heading_value: 'العنوان: {value}',
+      unnamed: 'بدون اسم',
+      opening_value: 'جارٍ فتح {value}',
+      focused_value: 'تم التركيز على {value}',
+      activated_value: 'تم تفعيل {value}',
+      target_link: 'الرابط',
+      target_button: 'الزر',
+      target_heading: 'العنوان',
+      target_input: 'حقل الإدخال',
+      target_element: 'العنصر',
+      summarizing_wait: 'أقوم بتلخيص هذه الصفحة... يرجى الانتظار.',
+      summarize_unavailable_page: 'عذراً، التلخيص غير متاح في هذه الصفحة.',
+      summarize_failed: 'عذراً، لم أتمكن من تلخيص هذه الصفحة.',
+      summarize_request_failed: 'عذراً، فشل طلب التلخيص. حاول مرة أخرى.',
+      tell_website_to_open: 'أخبرني بأي موقع تريد فتحه.',
+      open_site_unavailable: 'فتح موقع ويب غير متاح.',
+      open_site_failed: 'تعذر فتح هذا الموقع.',
+      wait_for_user_input: 'يرجى إدخال البيانات ثم أخبرني أن أتابع.',
+      newtab_try_open: 'لم أفهم ذلك. جرّب: "افتح يوتيوب".',
+      newtab_help_examples: 'جرّب: "افتح يوتيوب"، "افتح example dot com"، "ابحث عن الطقس".',
+      newtab_listening: 'أستمع الآن... قل "افتح يوتيوب".',
+      voice_unavailable_browser: 'الإدخال الصوتي غير متاح في هذا المتصفح.',
+      mic_access_blocked: 'الوصول إلى الميكروفون محظور. اسمح للميكروفون لهذه الإضافة لاستخدام الصوت.',
+      mic_busy: 'الميكروفون مشغول. أغلق التطبيقات أو التبويبات الأخرى التي تستخدمه ثم حاول مرة أخرى.',
+      opening_site: 'جارٍ فتح {value}...',
+      missing_url: 'اسم الموقع أو الرابط مفقود.'
+    }
+  };
+
+  var pendingLanguageLoads = {};
+
+  function getFetchImpl() {
+    return window.fetch;
+  }
+
+  function canonicalizeLocale(lang) {
+    var raw = String(lang || '').trim().replace(/_/g, '-');
+    if (!raw) return '';
+    try {
+      if (window.Intl && typeof window.Intl.Locale === 'function') {
+        return new window.Intl.Locale(raw).baseName;
+      }
+    } catch (_err) {
+      // fall through
+    }
+
+    var parts = raw.split('-').filter(Boolean);
+    if (!parts.length) return '';
+    parts[0] = parts[0].toLowerCase();
+    for (var i = 1; i < parts.length; i++) {
+      if (parts[i].length === 2) parts[i] = parts[i].toUpperCase();
+      else if (parts[i].length === 4) parts[i] = parts[i].charAt(0).toUpperCase() + parts[i].slice(1).toLowerCase();
+      else parts[i] = parts[i].toLowerCase();
+    }
+    return parts.join('-');
+  }
+
+  function normalizeLanguage(lang) {
+    var raw = String(lang || '').trim().toLowerCase();
+    if (!raw) return DEFAULT_LANGUAGE;
+    if (LANGUAGE_NAMES[raw]) return LANGUAGE_NAMES[raw];
+
+    var canonical = canonicalizeLocale(raw);
+    if (canonical) {
+      var primary = canonical.split('-')[0].toLowerCase();
+      if (LANGUAGE_NAMES[primary]) return LANGUAGE_NAMES[primary];
+      return primary || DEFAULT_LANGUAGE;
+    }
+
+    var parts = raw.split(/[-_]/);
+    if (parts[0] && LANGUAGE_NAMES[parts[0]]) return LANGUAGE_NAMES[parts[0]];
+    return parts[0] || DEFAULT_LANGUAGE;
+  }
+
+  function localeForLanguage(lang) {
+    var normalized = normalizeLanguage(lang);
+    if (LOCALES[normalized]) return LOCALES[normalized];
+    var canonical = canonicalizeLocale(lang);
+    if (canonical) return canonical;
+    return normalized || LOCALES[DEFAULT_LANGUAGE];
+  }
+
+  function interpolate(template, params) {
+    var text = String(template || '');
+    var values = params || {};
+    return text.replace(/\{(\w+)\}/g, function (_m, key) {
+      return Object.prototype.hasOwnProperty.call(values, key) ? String(values[key]) : '';
+    });
+  }
+
+  function sanitizeMessages(candidate, fallbackMessages) {
+    var safe = {};
+    var fallback = fallbackMessages || {};
+    Object.keys(fallback).forEach(function (key) {
+      var value = candidate && Object.prototype.hasOwnProperty.call(candidate, key) ? candidate[key] : null;
+      safe[key] = typeof value === 'string' && value.trim() ? value : fallback[key];
+    });
+    return safe;
+  }
+
+  function t(key, lang, params) {
+    var normalized = normalizeLanguage(lang);
+    var messages = MESSAGES[normalized] || MESSAGES[DEFAULT_LANGUAGE];
+    var fallbackMessages = MESSAGES[DEFAULT_LANGUAGE];
+    var template = messages[key];
+    if (template == null) template = fallbackMessages[key];
+    if (template == null) return key;
+    return interpolate(template, params);
+  }
+
+  function ensureLanguage(lang) {
+    var normalized = normalizeLanguage(lang);
+    if (!normalized || normalized === DEFAULT_LANGUAGE || MESSAGES[normalized]) {
+      return Promise.resolve(MESSAGES[normalized] || MESSAGES[DEFAULT_LANGUAGE]);
+    }
+    if (pendingLanguageLoads[normalized]) return pendingLanguageLoads[normalized];
+
+    var fetchImpl = getFetchImpl();
+    if (typeof fetchImpl !== 'function') {
+      return Promise.resolve(MESSAGES[DEFAULT_LANGUAGE]);
+    }
+
+    pendingLanguageLoads[normalized] = fetchImpl(DEFAULT_TRANSLATE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        language: normalized,
+        messages: MESSAGES[DEFAULT_LANGUAGE]
+      })
+    }).then(function (response) {
+      if (!response || !response.ok) throw new Error('Language pack request failed');
+      return response.json();
+    }).then(function (payload) {
+      var translated = sanitizeMessages(payload && payload.messages ? payload.messages : null, MESSAGES[DEFAULT_LANGUAGE]);
+      MESSAGES[normalized] = translated;
+      return translated;
+    }).catch(function () {
+      return MESSAGES[DEFAULT_LANGUAGE];
+    }).finally(function () {
+      delete pendingLanguageLoads[normalized];
+    });
+
+    return pendingLanguageLoads[normalized];
+  }
+
+  function countMatches(text, pattern) {
+    var matches = String(text || '').match(pattern);
+    return matches ? matches.length : 0;
+  }
+
+  function detectLanguage(text, fallbackLanguage) {
+    var raw = String(text || '').trim();
+    if (!raw) return normalizeLanguage(fallbackLanguage);
+    if (/[\u0600-\u06FF]/.test(raw)) return 'ar';
+
+    var lower = raw.toLowerCase();
+    var frScore = 0;
+    var enScore = 0;
+
+    if (/[àâçéèêëîïôûùüÿœæ]/i.test(raw)) frScore += 3;
+    frScore += countMatches(lower, /\b(bonjour|salut|merci|ouvre|ouvrir|recherche|resume|résume|résumé|decris|décris|titre|page|lien|bouton|suivant|precedent|précédent|aide|ecoute|écoute)\b/g);
+    enScore += countMatches(lower, /\b(open|search|scroll|summary|summarize|describe|title|button|link|page|help|listen|stop|start|next|previous|focus|activate)\b/g);
+
+    if (frScore > enScore && frScore > 0) return 'fr';
+    if (enScore > frScore && enScore > 0) return 'en';
+
+    return normalizeLanguage(fallbackLanguage);
+  }
+
+  function resolveNamedLanguage(name) {
+    var normalized = String(name || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[.,!?]/g, '');
+    return LANGUAGE_NAMES[normalized] || null;
+  }
+
+  function extractExplicitOutputLanguage(text) {
+    var raw = String(text || '').trim();
+    if (!raw) return null;
+    var lower = raw.toLowerCase();
+
+    var englishMatch = lower.match(/\b(?:answer|respond|reply|speak|say|summarize|summarise|describe)\b[\s\S]{0,24}?\b(?:in)\s+(english|french|arabic)\b/);
+    if (englishMatch && englishMatch[1]) return resolveNamedLanguage(englishMatch[1]);
+
+    var frenchMatch = lower.match(/\b(?:reponds|réponds|parle|dis|resume|résume|decris|décris)\b[\s\S]{0,24}?\ben\s+(anglais|francais|français|arabe)\b/);
+    if (frenchMatch && frenchMatch[1]) return resolveNamedLanguage(frenchMatch[1]);
+
+    if (/بالانجليزية|بالإنجليزية/.test(raw)) return 'en';
+    if (/بالفرنسية/.test(raw)) return 'fr';
+    if (/بالعربية/.test(raw)) return 'ar';
+
+    return null;
+  }
+
+  function resolveOutputLanguage(options) {
+    var opts = options || {};
+    var transcript = opts.transcript || '';
+    var explicit = extractExplicitOutputLanguage(transcript);
+    if (explicit) return normalizeLanguage(explicit);
+    return detectLanguage(transcript, opts.fallbackLanguage || DEFAULT_LANGUAGE);
+  }
+
+  window.NavableI18n = {
+    messages: MESSAGES,
+    normalizeLanguage: normalizeLanguage,
+    localeForLanguage: localeForLanguage,
+    detectLanguage: detectLanguage,
+    extractExplicitOutputLanguage: extractExplicitOutputLanguage,
+    resolveOutputLanguage: resolveOutputLanguage,
+    ensureLanguage: ensureLanguage,
+    t: t
+  };
+})();

--- a/src/common/speech.js
+++ b/src/common/speech.js
@@ -1,27 +1,115 @@
-// Lightweight Web Speech API wrapper for Navable
-// Exposes window.NavableSpeech with:
-// - supportsRecognition(): boolean
-// - createRecognizer(opts): { start(), stop(), on(event, handler) }
-// - speak(text): Promise<void>
+// Hybrid speech layer for Navable:
+// - primary: backend multilingual transcription via MediaRecorder + /api/transcribe
+// - fallback: browser Web Speech API when backend capture/transcription is unavailable
 (function () {
   if (typeof window === 'undefined' || window.NavableSpeech) return;
 
-  var NativeRecognition =
-    window.SpeechRecognition ||
-    window.webkitSpeechRecognition ||
-    window.mozSpeechRecognition ||
-    window.msSpeechRecognition;
+  var DEFAULT_TRANSCRIBE_URL = 'http://localhost:3000/api/transcribe';
+  var DEFAULT_HEALTH_URL = 'http://localhost:3000/health';
 
-  function supportsRecognition() {
-    return !!NativeRecognition;
+  function getSpeechEnv() {
+    return window.__NavableSpeechEnv || {};
   }
 
-  function createRecognizer(options) {
+  function getNativeRecognitionCtor() {
+    var env = getSpeechEnv();
+    return (
+      env.SpeechRecognition ||
+      window.SpeechRecognition ||
+      window.webkitSpeechRecognition ||
+      window.mozSpeechRecognition ||
+      window.msSpeechRecognition
+    );
+  }
+
+  function getAudioContextCtor() {
+    var env = getSpeechEnv();
+    return env.AudioContext || window.AudioContext || window.webkitAudioContext;
+  }
+
+  function getMediaRecorderCtor() {
+    var env = getSpeechEnv();
+    return env.MediaRecorder || window.MediaRecorder;
+  }
+
+  function getMediaDevices() {
+    var env = getSpeechEnv();
+    return env.mediaDevices || (window.navigator && window.navigator.mediaDevices);
+  }
+
+  function getFetchImpl() {
+    var env = getSpeechEnv();
+    return env.fetch || window.fetch;
+  }
+
+  function supportsNativeRecognition() {
+    return !!getNativeRecognitionCtor();
+  }
+
+  function supportsBackendRecognition() {
+    var MediaRecorderCtor = getMediaRecorderCtor();
+    var AudioContextCtor = getAudioContextCtor();
+    var mediaDevices = getMediaDevices();
+    var fetchImpl = getFetchImpl();
+    return !!(
+      fetchImpl &&
+      MediaRecorderCtor &&
+      AudioContextCtor &&
+      mediaDevices &&
+      typeof mediaDevices.getUserMedia === 'function'
+    );
+  }
+
+  function supportsRecognition() {
+    return supportsBackendRecognition() || supportsNativeRecognition();
+  }
+
+  function createEmitter(extraEvents) {
+    var listeners = {
+      result: [],
+      error: [],
+      start: [],
+      end: []
+    };
+
+    (extraEvents || []).forEach(function (name) {
+      listeners[name] = [];
+    });
+
+    function emit(type, payload) {
+      var list = listeners[type];
+      if (!list || !list.length) return;
+      list.forEach(function (fn) {
+        try {
+          fn(payload);
+        } catch (_err) {
+          // swallow handler errors
+        }
+      });
+    }
+
+    function on(type, handler) {
+      if (!listeners[type] || typeof handler !== 'function') return api;
+      listeners[type].push(handler);
+      return api;
+    }
+
+    var api = {
+      emit: emit,
+      on: on
+    };
+
+    return api;
+  }
+
+  function createNativeRecognizer(options) {
     options = options || {};
+    var NativeRecognition = getNativeRecognitionCtor();
     if (!NativeRecognition) {
       throw new Error('Speech recognition not supported');
     }
 
+    var emitter = createEmitter();
     var recognizer = new NativeRecognition();
     recognizer.lang = options.lang || 'en-US';
     recognizer.interimResults = !!options.interimResults;
@@ -33,12 +121,6 @@
     var isStarting = false;
     var isStarted = false;
     var restartTimer = null;
-    var listeners = {
-      result: [],
-      error: [],
-      start: [],
-      end: []
-    };
 
     function clearRestartTimer() {
       if (!restartTimer) return;
@@ -52,22 +134,9 @@
 
     function emitStartError(err) {
       var name = err && err.name ? String(err.name) : '';
-      // Treat "already started" as a no-op to keep start() idempotent.
       if (name === 'InvalidStateError') return;
       var code = (name === 'NotAllowedError' || name === 'SecurityError') ? 'not-allowed' : 'start-failed';
-      emit('error', { error: code, message: String(err || ''), raw: err });
-    }
-
-    function emit(type, payload) {
-      var list = listeners[type];
-      if (!list || !list.length) return;
-      list.forEach(function (fn) {
-        try {
-          fn(payload);
-        } catch (_err) {
-          // swallow handler errors
-        }
-      });
+      emitter.emit('error', { error: code, message: String(err || ''), raw: err });
     }
 
     recognizer.onresult = function (event) {
@@ -82,29 +151,26 @@
       }
       transcript = String(transcript || '').trim();
       if (!transcript) return;
-      if (!isFinal && options.onlyFinal !== false && !options.interimResults) {
-        // Skip interim results when onlyFinal is desired.
-        return;
-      }
-      emit('result', {
+      if (!isFinal && options.onlyFinal !== false && !options.interimResults) return;
+      emitter.emit('result', {
         transcript: transcript,
         isFinal: isFinal,
-        raw: event
+        raw: event,
+        provider: 'native'
       });
     };
 
     recognizer.onerror = function (event) {
       var code = event && event.error ? String(event.error) : 'unknown';
-      // On hard errors, stop auto-restart to avoid tight loops.
       if (code === 'not-allowed' || code === 'service-not-allowed' || code === 'network') {
         shouldRestart = false;
       }
-      // Ensure manual re-starts aren't blocked by stale state.
       isStarting = false;
-      emit('error', {
+      emitter.emit('error', {
         error: code,
         message: event && event.message ? String(event.message) : '',
-        raw: event
+        raw: event,
+        provider: 'native'
       });
     };
 
@@ -112,23 +178,24 @@
       clearRestartTimer();
       isStarting = false;
       isStarted = true;
-      emit('start');
+      emitter.emit('start', { provider: 'native' });
     };
 
     recognizer.onend = function (event) {
       clearRestartTimer();
       isStarting = false;
       isStarted = false;
-      emit('end', { raw: event });
+      emitter.emit('end', { raw: event, provider: 'native' });
       if (autoRestart && shouldRestart) {
-        // Guard against external start() calls while we're between restarts.
         isStarting = true;
         restartTimer = setTimeout(function () {
-          if (!(autoRestart && shouldRestart)) { isStarting = false; return; }
+          if (!(autoRestart && shouldRestart)) {
+            isStarting = false;
+            return;
+          }
           try {
             recognizer.start();
           } catch (_err) {
-            // restart failed; give up
             isStarting = false;
             shouldRestart = false;
           }
@@ -136,7 +203,7 @@
       }
     };
 
-    var api = {
+    return {
       start: function () {
         shouldRestart = autoRestart;
         if (isStarted || isStarting) return;
@@ -149,29 +216,532 @@
           emitStartError(err);
         }
       },
-      stop: function () {
+      stop: function (opts) {
+        opts = opts || {};
         shouldRestart = false;
         clearRestartTimer();
         isStarting = false;
+        if (opts.silent) {
+          recognizer.onend = function () {
+            clearRestartTimer();
+            isStarting = false;
+            isStarted = false;
+          };
+        }
         try {
           recognizer.stop();
         } catch (err) {
-          emit('error', { error: 'stop-failed', message: String(err || ''), raw: err });
+          emitter.emit('error', { error: 'stop-failed', message: String(err || ''), raw: err, provider: 'native' });
         }
       },
-      on: function (eventName, handler) {
-        if (!listeners[eventName]) return api;
-        if (typeof handler === 'function') {
-          listeners[eventName].push(handler);
-        }
-        return api;
-      }
+      on: emitter.on
     };
-
-    return api;
   }
 
-  function speak(text) {
+  function pickRecorderMimeType() {
+    var MediaRecorderCtor = getMediaRecorderCtor();
+    if (!MediaRecorderCtor || typeof MediaRecorderCtor.isTypeSupported !== 'function') {
+      return '';
+    }
+    var candidates = [
+      'audio/webm;codecs=opus',
+      'audio/webm',
+      'audio/ogg;codecs=opus',
+      'audio/mp4'
+    ];
+    for (var i = 0; i < candidates.length; i++) {
+      if (MediaRecorderCtor.isTypeSupported(candidates[i])) return candidates[i];
+    }
+    return '';
+  }
+
+  function blobToBase64(blob) {
+    return new Promise(function (resolve, reject) {
+      try {
+        var reader = new window.FileReader();
+        reader.onloadend = function () {
+          var result = String(reader.result || '');
+          var commaIndex = result.indexOf(',');
+          resolve(commaIndex >= 0 ? result.slice(commaIndex + 1) : result);
+        };
+        reader.onerror = function () {
+          reject(reader.error || new Error('Failed to read audio blob'));
+        };
+        reader.readAsDataURL(blob);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  function fetchWithTimeout(url, init, timeoutMs) {
+    return new Promise(function (resolve, reject) {
+      var done = false;
+      var timer = setTimeout(function () {
+        if (done) return;
+        done = true;
+        reject(new Error('Timed out'));
+      }, Math.max(0, timeoutMs || 0));
+
+      getFetchImpl()(url, init).then(function (response) {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        resolve(response);
+      }).catch(function (err) {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+  }
+
+  function createBackendRecognizer(options) {
+    options = options || {};
+    var emitter = createEmitter(['unavailable']);
+    var transcribeUrl = options.transcribeUrl || DEFAULT_TRANSCRIBE_URL;
+    var healthUrl = options.healthUrl || DEFAULT_HEALTH_URL;
+    var levelThreshold = typeof options.levelThreshold === 'number' ? options.levelThreshold : 0.018;
+    var silenceMs = typeof options.silenceMs === 'number' ? options.silenceMs : 1100;
+    var minSpeechMs = typeof options.minSpeechMs === 'number' ? options.minSpeechMs : 600;
+    var maxRecordingMs = typeof options.maxRecordingMs === 'number' ? options.maxRecordingMs : 12000;
+    var checkIntervalMs = typeof options.checkIntervalMs === 'number' ? options.checkIntervalMs : 100;
+    var AudioContextCtor = getAudioContextCtor();
+    var MediaRecorderCtor = getMediaRecorderCtor();
+
+    var mediaStream = null;
+    var audioContext = null;
+    var sourceNode = null;
+    var analyserNode = null;
+    var levelData = null;
+    var monitorTimer = null;
+    var recorder = null;
+    var recordedChunks = [];
+    var started = false;
+    var starting = false;
+    var shouldRun = false;
+    var healthChecked = false;
+    var healthAvailable = false;
+    var recordingStartedAt = 0;
+    var lastSpeechAt = 0;
+    var sawSpeech = false;
+    var pendingTranscription = false;
+    var discardPendingBlob = false;
+    var suppressEnd = false;
+
+    function cleanupNodes() {
+      if (monitorTimer) {
+        try {
+          clearInterval(monitorTimer);
+        } catch (_err) {
+          // ignore
+        }
+        monitorTimer = null;
+      }
+      try {
+        if (sourceNode) sourceNode.disconnect();
+      } catch (_err2) {
+        // ignore
+      }
+      try {
+        if (analyserNode) analyserNode.disconnect();
+      } catch (_err3) {
+        // ignore
+      }
+      sourceNode = null;
+      analyserNode = null;
+      levelData = null;
+
+      if (audioContext) {
+        try {
+          audioContext.close();
+        } catch (_err4) {
+          // ignore
+        }
+      }
+      audioContext = null;
+
+      if (mediaStream) {
+        try {
+          mediaStream.getTracks().forEach(function (track) {
+            try {
+              track.stop();
+            } catch (_err5) {
+              // ignore
+            }
+          });
+        } catch (_err6) {
+          // ignore
+        }
+      }
+      mediaStream = null;
+    }
+
+    function finalizeStop() {
+      cleanupNodes();
+      started = false;
+      starting = false;
+      recorder = null;
+      recordedChunks = [];
+      recordingStartedAt = 0;
+      lastSpeechAt = 0;
+      sawSpeech = false;
+      discardPendingBlob = false;
+      pendingTranscription = false;
+      if (suppressEnd) {
+        suppressEnd = false;
+        return;
+      }
+      emitter.emit('end', { provider: 'backend' });
+    }
+
+    function emitUnavailable(message, errorCode) {
+      emitter.emit('unavailable', {
+        error: errorCode || 'backend-unavailable',
+        message: String(message || ''),
+        provider: 'backend'
+      });
+    }
+
+    async function probeBackend() {
+      if (healthChecked) return healthAvailable;
+      healthChecked = true;
+      try {
+        var response = await fetchWithTimeout(healthUrl, { method: 'GET' }, 1500);
+        healthAvailable = !!(response && response.ok);
+      } catch (_err) {
+        healthAvailable = false;
+      }
+      return healthAvailable;
+    }
+
+    function getAudioLevel() {
+      if (!analyserNode || !levelData) return 0;
+      analyserNode.getByteTimeDomainData(levelData);
+      var sum = 0;
+      for (var i = 0; i < levelData.length; i++) {
+        var centered = (levelData[i] - 128) / 128;
+        sum += centered * centered;
+      }
+      return Math.sqrt(sum / levelData.length);
+    }
+
+    function resetRecordingState() {
+      recorder = null;
+      recordedChunks = [];
+      recordingStartedAt = 0;
+      lastSpeechAt = 0;
+      sawSpeech = false;
+      discardPendingBlob = false;
+    }
+
+    async function transcribeBlob(blob) {
+      pendingTranscription = true;
+      try {
+        var audioBase64 = await blobToBase64(blob);
+        var response = await getFetchImpl()(transcribeUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            audioBase64: audioBase64,
+            mimeType: blob.type || 'audio/webm'
+          })
+        });
+        if (!response.ok) {
+          throw new Error('Transcription failed with status ' + response.status);
+        }
+        var payload = await response.json();
+        var transcript = payload && payload.text ? String(payload.text).trim() : '';
+        if (!transcript) {
+          emitter.emit('error', { error: 'no-speech', message: '', provider: 'backend', raw: payload });
+          return;
+        }
+        emitter.emit('result', {
+          transcript: transcript,
+          isFinal: true,
+          language: payload && payload.language ? String(payload.language) : '',
+          raw: payload,
+          provider: 'backend'
+        });
+      } catch (err) {
+        emitUnavailable(err && err.message ? err.message : 'Backend transcription unavailable', 'network');
+      } finally {
+        pendingTranscription = false;
+      }
+    }
+
+    function stopRecorder() {
+      if (!recorder || recorder.state === 'inactive') return;
+      try {
+        recorder.stop();
+      } catch (err) {
+        emitter.emit('error', { error: 'stop-failed', message: String(err || ''), raw: err, provider: 'backend' });
+      }
+    }
+
+    function startRecorder() {
+      if (!mediaStream || recorder || pendingTranscription) return;
+
+      recordedChunks = [];
+      discardPendingBlob = false;
+
+      var recorderOptions = {};
+      var mimeType = pickRecorderMimeType();
+      if (mimeType) recorderOptions.mimeType = mimeType;
+
+      try {
+        recorder = new MediaRecorderCtor(mediaStream, recorderOptions);
+      } catch (err) {
+        emitter.emit('error', { error: 'start-failed', message: String(err || ''), raw: err, provider: 'backend' });
+        return;
+      }
+
+      recordingStartedAt = Date.now();
+      lastSpeechAt = recordingStartedAt;
+      sawSpeech = false;
+
+      recorder.ondataavailable = function (event) {
+        if (event && event.data && event.data.size > 0) {
+          recordedChunks.push(event.data);
+        }
+      };
+
+      recorder.onerror = function (event) {
+        emitter.emit('error', {
+          error: 'audio-capture',
+          message: event && event.error ? String(event.error.message || event.error.name || '') : '',
+          raw: event,
+          provider: 'backend'
+        });
+      };
+
+      recorder.onstop = function () {
+        var shouldDiscard = discardPendingBlob || !shouldRun || !sawSpeech;
+        var blob = new window.Blob(recordedChunks, { type: recorder && recorder.mimeType ? recorder.mimeType : mimeType || 'audio/webm' });
+        resetRecordingState();
+        if (shouldDiscard || blob.size === 0) {
+          if (shouldRun && started && !pendingTranscription && !recorder) {
+            startRecorder();
+            return;
+          }
+          if (!shouldRun && !pendingTranscription) finalizeStop();
+          return;
+        }
+        transcribeBlob(blob).finally(function () {
+          if (shouldRun && started && !recorder) {
+            startRecorder();
+            return;
+          }
+          if (!shouldRun && !recorder) finalizeStop();
+        });
+      };
+
+      try {
+        recorder.start(250);
+      } catch (err2) {
+        recorder = null;
+        emitter.emit('error', { error: 'start-failed', message: String(err2 || ''), raw: err2, provider: 'backend' });
+      }
+    }
+
+    function monitorAudio() {
+      if (!shouldRun || !started || pendingTranscription) return;
+      if (!recorder) {
+        startRecorder();
+        return;
+      }
+      var level = getAudioLevel();
+      var now = Date.now();
+
+      if (level >= levelThreshold) {
+        lastSpeechAt = now;
+        sawSpeech = true;
+        return;
+      }
+
+      if (now - recordingStartedAt >= maxRecordingMs) {
+        stopRecorder();
+        return;
+      }
+
+      if (sawSpeech && now - lastSpeechAt >= silenceMs && now - recordingStartedAt >= minSpeechMs) {
+        stopRecorder();
+      }
+    }
+
+    function mapCaptureError(err) {
+      var name = err && err.name ? String(err.name) : '';
+      if (name === 'NotAllowedError' || name === 'SecurityError') {
+        return { error: 'not-allowed', message: String(err && err.message ? err.message : '') };
+      }
+      if (name === 'NotFoundError' || name === 'NotReadableError' || name === 'AbortError') {
+        return { error: 'audio-capture', message: String(err && err.message ? err.message : '') };
+      }
+      return { error: 'start-failed', message: String(err && err.message ? err.message : '') };
+    }
+
+    return {
+      start: function () {
+        if (started || starting) return;
+        shouldRun = true;
+        starting = true;
+
+        probeBackend().then(function (available) {
+          if (!available) {
+            shouldRun = false;
+            starting = false;
+            emitUnavailable('Backend transcription unavailable');
+            return;
+          }
+
+          return getMediaDevices().getUserMedia({ audio: true }).then(function (stream) {
+            if (!shouldRun) {
+              try {
+                stream.getTracks().forEach(function (track) { track.stop(); });
+              } catch (_err) {
+                // ignore
+              }
+              starting = false;
+              return;
+            }
+
+            mediaStream = stream;
+            audioContext = new AudioContextCtor();
+            return Promise.resolve(audioContext.resume && audioContext.resume()).catch(function () {
+              return undefined;
+            }).then(function () {
+              sourceNode = audioContext.createMediaStreamSource(mediaStream);
+              analyserNode = audioContext.createAnalyser();
+              analyserNode.fftSize = 2048;
+              analyserNode.smoothingTimeConstant = 0.1;
+              levelData = new Uint8Array(analyserNode.fftSize);
+              sourceNode.connect(analyserNode);
+              started = true;
+              starting = false;
+              startRecorder();
+              emitter.emit('start', { provider: 'backend' });
+              monitorTimer = setInterval(monitorAudio, Math.max(40, checkIntervalMs));
+            });
+          });
+        }).catch(function (err) {
+          shouldRun = false;
+          starting = false;
+          var mapped = mapCaptureError(err);
+          emitter.emit('error', {
+            error: mapped.error,
+            message: mapped.message,
+            raw: err,
+            provider: 'backend'
+          });
+        });
+      },
+      stop: function (opts) {
+        opts = opts || {};
+        shouldRun = false;
+        suppressEnd = !!opts.silent;
+        discardPendingBlob = true;
+        if (recorder && recorder.state !== 'inactive') {
+          stopRecorder();
+          return;
+        }
+        finalizeStop();
+      },
+      on: emitter.on
+    };
+  }
+
+  function createRecognizer(options) {
+    options = options || {};
+    var emitter = createEmitter();
+    var nativeRecognizer = supportsNativeRecognition() ? createNativeRecognizer(options) : null;
+    var backendRecognizer = supportsBackendRecognition() && options.preferBackend !== false
+      ? createBackendRecognizer(options)
+      : null;
+    var activeRecognizer = null;
+    var desiredRunning = false;
+    var backendDisabled = !backendRecognizer;
+    var suppressBackendEnd = false;
+
+    function switchToNativeFromBackend() {
+      if (!nativeRecognizer) return false;
+      backendDisabled = true;
+      suppressBackendEnd = true;
+      if (activeRecognizer === backendRecognizer) {
+        backendRecognizer.stop({ silent: true });
+      }
+      activeRecognizer = nativeRecognizer;
+      nativeRecognizer.start();
+      return true;
+    }
+
+    function forward(recognizer, type) {
+      if (!recognizer) return;
+      recognizer.on(type, function (payload) {
+        if (recognizer === backendRecognizer && type === 'error') {
+          var code = payload && payload.error ? String(payload.error) : '';
+          if (code === 'no-speech') {
+            if (desiredRunning && switchToNativeFromBackend()) {
+              return;
+            }
+          }
+        }
+        if (type === 'start' || type === 'end') {
+          if (recognizer !== activeRecognizer) return;
+          if (type === 'end' && suppressBackendEnd && recognizer === backendRecognizer) {
+            suppressBackendEnd = false;
+            return;
+          }
+        }
+        emitter.emit(type, payload);
+      });
+    }
+
+    forward(nativeRecognizer, 'result');
+    forward(nativeRecognizer, 'error');
+    forward(nativeRecognizer, 'start');
+    forward(nativeRecognizer, 'end');
+    forward(backendRecognizer, 'result');
+    forward(backendRecognizer, 'error');
+    forward(backendRecognizer, 'start');
+    forward(backendRecognizer, 'end');
+
+    if (backendRecognizer) {
+      backendRecognizer.on('unavailable', function (payload) {
+        backendDisabled = true;
+        if (desiredRunning && switchToNativeFromBackend()) {
+          return;
+        }
+        emitter.emit('error', payload);
+      });
+    }
+
+    return {
+      start: function () {
+        desiredRunning = true;
+        if (!backendDisabled && backendRecognizer) {
+          activeRecognizer = backendRecognizer;
+          backendRecognizer.start();
+          return;
+        }
+        if (nativeRecognizer) {
+          activeRecognizer = nativeRecognizer;
+          nativeRecognizer.start();
+          return;
+        }
+        throw new Error('Speech recognition not supported');
+      },
+      stop: function () {
+        desiredRunning = false;
+        if (!activeRecognizer) return;
+        activeRecognizer.stop();
+        activeRecognizer = null;
+      },
+      on: emitter.on
+    };
+  }
+
+  function speak(text, opts) {
     return new Promise(function (resolve) {
       try {
         var synth = window.speechSynthesis;
@@ -179,6 +749,8 @@
           return resolve();
         }
         var utterance = new window.SpeechSynthesisUtterance(String(text || ''));
+        var lang = opts && opts.lang ? String(opts.lang).trim() : '';
+        if (lang) utterance.lang = lang;
         utterance.onend = function () {
           resolve();
         };
@@ -194,6 +766,8 @@
 
   window.NavableSpeech = {
     supportsRecognition: supportsRecognition,
+    supportsBackendRecognition: supportsBackendRecognition,
+    supportsNativeRecognition: supportsNativeRecognition,
     createRecognizer: createRecognizer,
     speak: speak
   };

--- a/src/content.js
+++ b/src/content.js
@@ -35,12 +35,79 @@
     }
   }
 
+  var i18n = window.NavableI18n || null;
+
+  function normalizeOutputLanguage(lang) {
+    if (i18n && typeof i18n.normalizeLanguage === 'function') {
+      return i18n.normalizeLanguage(lang);
+    }
+    return String(lang || 'en').toLowerCase().split(/[-_]/)[0] || 'en';
+  }
+
+  function outputLocale(lang) {
+    if (i18n && typeof i18n.localeForLanguage === 'function') {
+      return i18n.localeForLanguage(lang);
+    }
+    return String(lang || 'en-US');
+  }
+
+  function currentOutputLanguage() {
+    return normalizeOutputLanguage(outputLanguage || settings.language || recogLang || 'en-US');
+  }
+
+  function translate(key, params, lang) {
+    var resolvedLang = normalizeOutputLanguage(lang || currentOutputLanguage());
+    if (i18n && typeof i18n.t === 'function') {
+      return i18n.t(key, resolvedLang, params);
+    }
+    return key;
+  }
+
+  function ensureOutputLanguageReady(lang) {
+    var resolvedLang = normalizeOutputLanguage(lang || currentOutputLanguage());
+    if (i18n && typeof i18n.ensureLanguage === 'function') {
+      return i18n.ensureLanguage(resolvedLang);
+    }
+    return Promise.resolve();
+  }
+
+  function resolveTranscriptLanguage(text) {
+    if (i18n && typeof i18n.resolveOutputLanguage === 'function') {
+      return i18n.resolveOutputLanguage({
+        transcript: text,
+        fallbackLanguage: currentOutputLanguage()
+      });
+    }
+    return currentOutputLanguage();
+  }
+
+  function localizeTarget(target, lang) {
+    var resolved = normalizeOutputLanguage(lang || currentOutputLanguage());
+    if (target === 'link') return translate('target_link', null, resolved);
+    if (target === 'button') return translate('target_button', null, resolved);
+    if (target === 'heading') return translate('target_heading', null, resolved);
+    if (target === 'input') return translate('target_input', null, resolved);
+    return translate('target_element', null, resolved);
+  }
+
+  function setOutputLanguageFromTranscript(text, detectedLanguage) {
+    if (detectedLanguage) {
+      outputLanguage = normalizeOutputLanguage(detectedLanguage);
+      return outputLanguage;
+    }
+    outputLanguage = resolveTranscriptLanguage(text);
+    return outputLanguage;
+  }
+
   // Fallback hotkey: Alt+Shift+;
   document.addEventListener(
     'keydown',
     (e) => {
       if (e.altKey && e.shiftKey && e.key === ';') {
-        announce('Navable: test announcement (fallback hotkey).', { mode: 'polite' });
+        announce(translate('navable_test_announcement'), {
+          mode: 'polite',
+          lang: outputLocale(currentOutputLanguage())
+        });
       }
     },
     { capture: true }
@@ -50,12 +117,23 @@
   if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.onMessage) {
     chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       if (msg && msg.type === 'announce') {
-        announce(msg.text || 'Navable: announcement.', { mode: msg.mode || 'polite', priority: !!msg.priority });
+        announce(msg.text || translate('generic_announcement'), {
+          mode: msg.mode || 'polite',
+          priority: !!msg.priority,
+          lang: msg.lang || outputLocale(currentOutputLanguage())
+        });
         return;
       }
       if (msg && msg.type === 'navable:announce') {
-        announce(msg.text || 'Navable: announcement.', { mode: msg.mode || 'polite', priority: !!msg.priority });
-        sendResponse && sendResponse({ ok: true });
+        if (msg.lang) outputLanguage = normalizeOutputLanguage(msg.lang);
+        ensureOutputLanguageReady(outputLanguage).finally(function () {
+          announce(msg.text || translate('generic_announcement'), {
+            mode: msg.mode || 'polite',
+            priority: !!msg.priority,
+            lang: msg.lang || outputLocale(currentOutputLanguage())
+          });
+          sendResponse && sendResponse({ ok: true });
+        });
         return true;
       }
       if (msg && msg.type === 'navable:getStructure') {
@@ -121,7 +199,10 @@
   // Speak on activation (top window only)
   try {
     if (window.top === window) {
-      announce('Navable is ready. Say “help” to hear example commands.', { mode: 'polite' });
+      announce(translate('navable_ready'), {
+        mode: 'polite',
+        lang: outputLocale(currentOutputLanguage())
+      });
     }
   } catch (_e) {
     // ignore cross-origin frame access errors
@@ -551,7 +632,7 @@
       return { ok: true, message: 'Moved heading ' + (dir === 'prev' ? 'previous' : 'next') };
     }
     if (action === 'wait_for_user_input') {
-      speak(step.prompt || 'Please provide input, then tell me to continue.');
+      speak(step.prompt || translate('wait_for_user_input'));
       return { ok: true, message: 'Waiting for user input' };
     }
     return { ok: false, message: 'Unknown action ' + action };
@@ -589,6 +670,7 @@
   var lastUnknownCmdAt = 0;
   var lastMicBusyAt = 0;
   var recogLang = 'en-US';
+  var outputLanguage = 'en';
   var transientRestoreTimer = null;
   var startRetryTimer = null;
   var startRetryCount = 0;
@@ -617,12 +699,13 @@
     var msg = String(text || '');
     var isTransient = !!opts.transient;
     var restoreMs = typeof opts.restoreMs === 'number' ? opts.restoreMs : 2500;
+    var lang = opts && opts.lang ? String(opts.lang) : outputLocale(currentOutputLanguage());
 
     if (!isTransient) {
       lastSpoken = msg;
       clearTransientRestoreTimer();
       // Rely on the ARIA live region + screen reader; do not use browser text-to-speech.
-      announce(lastSpoken, { mode: mode });
+      announce(lastSpoken, { mode: mode, lang: lang });
       return;
     }
 
@@ -634,7 +717,7 @@
     } catch (_err) {
       previousText = '';
     }
-    announce(msg, { mode: mode });
+    announce(msg, { mode: mode, lang: lang });
 
     clearTransientRestoreTimer();
     transientRestoreTimer = setTimeout(function () {
@@ -688,7 +771,10 @@
   function ensureRecognizer() {
     if (recognizer || !isVoiceSupported()) return recognizer;
     recognizer = speech.createRecognizer({ lang: recogLang || 'en-US', interimResults: false, continuous: true, autoRestart: true });
-    recognizer.on('result', function (ev) { if (!ev || !ev.transcript) return; handleTranscript(ev.transcript); });
+    recognizer.on('result', function (ev) {
+      if (!ev || !ev.transcript) return;
+      handleTranscript(ev.transcript, ev.language || '');
+    });
     recognizer.on('error', function (e) {
       console.warn('[Navable] speech error', e && e.error);
       try {
@@ -699,7 +785,7 @@
             var now2 = Date.now();
             if (now2 - lastMicBusyAt > 15000) {
               lastMicBusyAt = now2;
-              speakTransient('Microphone is busy in another tab or app. Retrying…', 3500);
+              speakTransient(translate('microphone_busy_retry'), 3500);
             }
             clearStartRetryTimer();
             startRetryCount = Math.min(10, startRetryCount + 1);
@@ -718,13 +804,13 @@
 	        } else if (code === 'not-allowed' || code === 'service-not-allowed') {
 	          listening = false;
 	          manualListening = false;
-	          speak('Speech recognition is not allowed in this browser.');
+	          speak(translate('speech_not_allowed'));
 	        } else if (code === 'network') {
 	          listening = false;
 	          manualListening = false;
-	          speak('Speech recognition is unavailable due to a network issue.');
+	          speak(translate('speech_network_issue'));
 	        } else {
-	          speak('Speech recognition had a problem. Please try again.');
+	          speak(translate('speech_problem_retry'));
 	        }
       } catch (_err) {
         // ignore secondary failures
@@ -745,12 +831,12 @@
     startRetryCount = 0;
     ensureRecognizer();
     if (!recognizer) {
-      if (opts.announce !== false) speak('Speech recognition not available.');
+      if (opts.announce !== false) speak(translate('speech_not_available'));
       listening = false;
       return;
     }
     listening = true;
-    if (opts.announce) speak('Listening. Say “help” to hear example commands.');
+    if (opts.announce) speak(translate('listening_help'));
     try { recognizer.start(); } catch (_err) { /* errors are handled via recognizer error events */ }
   }
 
@@ -759,7 +845,7 @@
     listening = false;
     clearStartRetryTimer();
     startRetryCount = 0;
-    if (opts.announce) speak('Stopped listening. Press Alt+Shift+M to start again.');
+    if (opts.announce) speak(translate('stopped_listening'));
     try { if (recognizer) recognizer.stop(); } catch (_err) { /* ignore */ }
   }
 
@@ -804,22 +890,56 @@
     // ignore
   }
 
+  function matchesAnyPattern(text, patterns) {
+    for (var i = 0; i < patterns.length; i++) {
+      if (patterns[i].test(text)) return true;
+    }
+    return false;
+  }
+
+  function extractSearchSiteQuery(t) {
+    var s = String(t || '').trim().toLowerCase();
+    if (!s) return null;
+
+    var en = s.match(/^(search|google|look up|find)\s+(for\s+)?(.+)$/);
+    if (en && en[3]) return 'search for ' + String(en[3]).trim();
+
+    var fr = s.match(/^(cherche|recherche)\s+(.+)$/);
+    if (fr && fr[2]) return 'search for ' + String(fr[2]).trim();
+
+    var ar = s.match(/^(ابحث|فتش)(\s+عن)?\s+(.+)$/);
+    if (ar && ar[3]) return 'search for ' + String(ar[3]).trim();
+
+    return null;
+  }
+
   function extractOpenSiteQuery(t) {
     var s = String(t || '').trim().toLowerCase();
     if (!s) return null;
 
     // Avoid conflicting with in-page intents like "open first link" or "press button".
-    if (/\b(link|button|heading)\b/.test(s)) return null;
+    if (/\b(link|button|heading|lien|bouton|titre)\b|رابط|زر|عنوان/.test(s)) return null;
 
-    // Arabic: "افتح <شيء>"
-    var ar = s.match(/^افتح\s+(.+)$/);
-    if (ar && ar[1]) return String(ar[1]).trim();
+    // Arabic website intents.
+    var ar = s.match(/^(افتح|اذهب\s+إلى|اذهب\s+الى|روح\s+على|روح\s+إلى|روح\s+الى|انتقل\s+إلى|انتقل\s+الى)\s+(.+)$/);
+    if (ar && ar[2]) return String(ar[2]).trim();
 
-    // English: "open (me) <site>"
-    if (!/^(open|navigate to|take me to)\b/.test(s)) return null;
+    // French website intents.
+    var fr = s.match(/^(ouvre|va(?:s)?\s+(?:a|à)|aller?\s+(?:a|à)|visite|lance)\s+(.+)$/);
+    if (fr && fr[2]) {
+      return String(fr[2])
+        .trim()
+        .replace(/^(le|la|les|un|une)\b/, '')
+        .trim()
+        .replace(/^(site|page|onglet)\b/, '')
+        .trim();
+    }
+
+    // English: flexible website intents.
+    if (!/^(open|navigate to|take me to|go to|visit|bring up|launch)\b/.test(s)) return null;
 
     var q = s
-      .replace(/^(open(\s+up)?|navigate to|take me to)\b/, '')
+      .replace(/^(open(\s+up)?|navigate to|take me to|go to|visit|bring up|launch)\b/, '')
       .trim()
       .replace(/^(me|for me)\b/, '')
       .trim()
@@ -846,11 +966,14 @@
     var label;
 
     // Help / examples.
-    if (/^(help|help me|commands|show commands|what can i say\??)$/.test(t) || /مساعدة/.test(t)) {
+    if (
+      /^(help|help me|commands|show commands|what can i say\??|aide|montre les commandes|que puis-je dire\??)$/.test(t) ||
+      /مساعدة/.test(t)
+    ) {
       return { type: 'help' };
     }
 
-    // English summary triggers + common Arabic phrasing.
+    // Summary/orientation triggers in English, French, and Arabic.
     if (
       t.includes('summarize') ||
       t.includes('summary') ||
@@ -859,6 +982,10 @@
       t.includes("what's on this page") ||
       t.includes('what is on this page') ||
       t.includes("what's this page") ||
+      /r[ée]sum[ée]?.*cette page/.test(t) ||
+      /d[ée]cri(s|re).*cette page/.test(t) ||
+      /c[' ]?est quoi cette page/.test(t) ||
+      /qu[' ]?est[- ]ce que cette page/.test(t) ||
       /ما هذه الصفحه/.test(t) ||
       /ما هذه الصفحة/.test(t) ||
       /ما هو محتوى الصفحة/.test(t) ||
@@ -868,17 +995,20 @@
       return { type: 'summarize', command: original || 'Summarize this page' };
     }
 
+    var searchQuery = extractSearchSiteQuery(t);
+    if (searchQuery) return { type: 'open_site', query: searchQuery, newTab: true };
+
     // Open a new website (dynamic) in a new tab.
     var siteQuery = extractOpenSiteQuery(t);
     if (siteQuery) return { type: 'open_site', query: siteQuery, newTab: true };
 
-    if (/(scroll )?down/.test(t) || /scroll down/.test(t)) return { type: 'scroll', dir: 'down' };
-    if (/(scroll )?up/.test(t) || /scroll up/.test(t)) return { type: 'scroll', dir: 'up' };
-    if (/top/.test(t) || /scroll (to )?top/.test(t)) return { type: 'scroll', dir: 'top' };
-    if (/bottom/.test(t) || /scroll (to )?bottom/.test(t)) return { type: 'scroll', dir: 'bottom' };
-    if (/read (the )?title/.test(t) || /read title/.test(t)) return { type: 'read', what: 'title' };
-    if (/^read (the )?selection/.test(t) || /^read selected/.test(t)) return { type: 'read', what: 'selection' };
-    if (/^read (the )?(focus|focused|this)$/.test(t)) return { type: 'read', what: 'focused' };
+    if (matchesAnyPattern(t, [/(scroll )?down/, /scroll down/, /\bdescend(s)?\b/, /plus bas/, /انزل|نز[ّل]|مرر.*(للأسفل|للاسفل)/])) return { type: 'scroll', dir: 'down' };
+    if (matchesAnyPattern(t, [/(scroll )?up/, /scroll up/, /\bmonte\b/, /plus haut/, /اطلع|اصعد|مرر.*(للأعلى|للاعلى)/])) return { type: 'scroll', dir: 'up' };
+    if (matchesAnyPattern(t, [/\btop\b/, /scroll (to )?top/, /en haut/, /أعلى الصفحة|اعلى الصفحة/])) return { type: 'scroll', dir: 'top' };
+    if (matchesAnyPattern(t, [/\bbottom\b/, /scroll (to )?bottom/, /en bas/, /أسفل الصفحة|اسفل الصفحة/])) return { type: 'scroll', dir: 'bottom' };
+    if (matchesAnyPattern(t, [/read (the )?title/, /read title/, /lis le titre/, /quel est le titre/, /اقر[أا] العنوان|ما عنوان الصفحة/])) return { type: 'read', what: 'title' };
+    if (matchesAnyPattern(t, [/^read (the )?selection/, /^read selected/, /lis la s[ée]lection/, /اقر[أا] التحديد/])) return { type: 'read', what: 'selection' };
+    if (matchesAnyPattern(t, [/^read (the )?(focus|focused|this)$/, /sur quoi suis[- ]je/, /ما العنصر المحدد|على ماذا انا|على ماذا أنا/])) return { type: 'read', what: 'focused' };
 
     // Explicit label-based intents first
     if ((/^open/.test(t) || /^click/.test(t)) && /link/.test(t) && (label = extractLabel(t, 'link'))) return { type: 'open', target: 'link', label: label };
@@ -918,8 +1048,8 @@
     if (/next .*heading/.test(t) || /^next heading/.test(t)) return { type: 'move', target: 'heading', dir: 'next' };
     if (/previous .*heading/.test(t) || /^previous heading/.test(t) || /prev .*heading/.test(t)) return { type: 'move', target: 'heading', dir: 'prev' };
 
-    if (/repeat/.test(t)) return { type: 'repeat' };
-    if (/stop/.test(t)) return { type: 'stop' };
+    if (/repeat|r[ée]p[èe]te|كرر/.test(t)) return { type: 'repeat' };
+    if (/stop|arr[êe]te|stoppe|توقف|قف|اسكت/.test(t)) return { type: 'stop' };
     return null;
   }
 
@@ -1028,7 +1158,7 @@
       var now = Date.now();
       if (now - lastUnknownCmdAt < 5000) return;
       lastUnknownCmdAt = now;
-      speakTransient('I did not catch that. Say “help” to hear example commands.', 3200);
+      speakTransient(translate('unknown_command'), 3200);
       return;
     }
     if (cmd.type === 'help') { speakHelp(); return; }
@@ -1040,19 +1170,19 @@
       var amount = Math.floor(window.innerHeight * 0.8);
       if (cmd.dir === 'down') {
         window.scrollBy({ top: amount, behavior: 'smooth' });
-        speak('Scrolled down.');
+        speak(translate('scrolled_down'));
       } else if (cmd.dir === 'up') {
         window.scrollBy({ top: -amount, behavior: 'smooth' });
-        speak('Scrolled up.');
+        speak(translate('scrolled_up'));
       } else if (cmd.dir === 'top') {
         window.scrollTo({ top: 0, behavior: 'smooth' });
-        speak('Scrolled to top.');
+        speak(translate('scrolled_top'));
       } else if (cmd.dir === 'bottom') {
         window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
-        speak('Scrolled to bottom.');
+        speak(translate('scrolled_bottom'));
       } else {
         window.scrollBy({ top: amount, behavior: 'smooth' });
-        speak('Scrolled down.');
+        speak(translate('scrolled_down'));
       }
       console.log('[Navable] Action: scroll', cmd.dir);
       return;
@@ -1060,14 +1190,14 @@
     if (cmd.type === 'read' && cmd.what === 'title') {
       var h1 = document.querySelector('h1');
       var title = (h1 && h1.innerText) || document.title || '';
-      speak('Title: ' + (title || 'not found'));
+      speak(translate('title_value', { value: title || translate('value_not_found') }));
       console.log('[Navable] Action: read title');
       return;
     }
     if (cmd.type === 'read' && cmd.what === 'selection') {
       var sel = '';
       try { sel = String(window.getSelection && window.getSelection().toString() || '').trim(); } catch (_err) { /* selection failed */ }
-      if (sel) { speak('Selection: ' + sel); } else { speak('No selection.'); }
+      if (sel) { speak(translate('selection_value', { value: sel })); } else { speak(translate('no_selection')); }
       console.log('[Navable] Action: read selection');
       return;
     }
@@ -1076,43 +1206,43 @@
       if (fe) {
         var fl = (fe.dataset && fe.dataset.navableLabel) || fe.getAttribute && fe.getAttribute('aria-label') || fe.innerText || fe.textContent || '';
         fl = String(fl || '').trim();
-        speak(fl || 'No focused element text.');
+        speak(fl || translate('no_focused_text'));
       } else {
-        speak('No focused element.');
+        speak(translate('no_focused_element'));
       }
       console.log('[Navable] Action: read focused');
       return;
     }
     if (cmd.type === 'read' && cmd.target === 'heading' && cmd.label) {
       var elhL = findByLabel('heading', cmd.label);
-      if (!elhL) { speak('I did not find that heading.'); return; }
+      if (!elhL) { speak(translate('not_found_heading')); return; }
       var lblhL = elhL.dataset.navableLabel || elhL.innerText || elhL.textContent || '';
-      speak('Heading: ' + (lblhL.trim() || 'unnamed'));
+      speak(translate('heading_value', { value: lblhL.trim() || translate('unnamed') }));
       console.log('[Navable] Action: read heading by label', cmd.label);
       return;
     }
     if (cmd.type === 'read' && cmd.target === 'heading' && !cmd.label) {
       var elh = pickNth('heading', cmd.n || 1);
-      if (!elh) { speak('I did not find a heading.'); return; }
+      if (!elh) { speak(translate('not_found_generic', { target: localizeTarget('heading') })); return; }
       var lblh = elh.dataset.navableLabel || elh.innerText || elh.textContent || '';
-      speak('Heading: ' + (lblh.trim() || 'unnamed'));
+      speak(translate('heading_value', { value: lblh.trim() || translate('unnamed') }));
       console.log('[Navable] Action: read heading', cmd.n);
       return;
     }
     if (cmd.type === 'open' && cmd.target === 'link' && cmd.label) {
       var ellL = findByLabel('link', cmd.label);
-      if (!ellL) { speak('I did not find that link.'); return; }
+      if (!ellL) { speak(translate('not_found_link')); return; }
       var lbllL = ellL.dataset.navableLabel || ellL.innerText || ellL.textContent || '';
-      speak('Opening ' + (lbllL.trim() || 'link'));
+      speak(translate('opening_value', { value: lbllL.trim() || translate('target_link') }));
       ellL.click();
       console.log('[Navable] Action: open link by label', cmd.label);
       return;
     }
     if (cmd.type === 'open' && cmd.target === 'link' && !cmd.label) {
       var ell = pickNth('link', cmd.n || 1);
-      if (!ell) { speak('I did not find a link.'); return; }
+      if (!ell) { speak(translate('not_found_generic', { target: localizeTarget('link') })); return; }
       var lbll = ell.dataset.navableLabel || ell.innerText || ell.textContent || '';
-      speak('Opening ' + (lbll.trim() || 'link'));
+      speak(translate('opening_value', { value: lbll.trim() || translate('target_link') }));
       // Prefer click to follow anchors and SPA handlers
       ell.click();
       console.log('[Navable] Action: open link', cmd.n);
@@ -1120,70 +1250,70 @@
     }
     if (cmd.type === 'focus' && cmd.target === 'button' && cmd.label) {
       var elbL = findByLabel('button', cmd.label);
-      if (!elbL) { speak('I did not find that button.'); return; }
+      if (!elbL) { speak(translate('not_found_button')); return; }
       try { elbL.focus(); } catch (_err) { /* focus failed */ }
       var lblbL = elbL.dataset.navableLabel || elbL.innerText || elbL.textContent || '';
-      speak('Focused ' + (lblbL.trim() || 'button'));
+      speak(translate('focused_value', { value: lblbL.trim() || translate('target_button') }));
       console.log('[Navable] Action: focus button by label', cmd.label);
       return;
     }
     if (cmd.type === 'focus' && cmd.target === 'button' && !cmd.label) {
       var elb = pickNth('button', cmd.n || 1);
-      if (!elb) { speak('I did not find a button.'); return; }
+      if (!elb) { speak(translate('not_found_generic', { target: localizeTarget('button') })); return; }
       try { elb.focus(); } catch (_err) { /* focus failed */ }
       var lblb = elb.dataset.navableLabel || elb.innerText || elb.textContent || '';
-      speak('Focused ' + (lblb.trim() || 'button'));
+      speak(translate('focused_value', { value: lblb.trim() || translate('target_button') }));
       console.log('[Navable] Action: focus button', cmd.n);
       return;
     }
     if (cmd.type === 'activate' && cmd.target === 'focused') {
       var aef = document.activeElement;
-      if (!aef) { speak('No focused element.'); return; }
+      if (!aef) { speak(translate('no_focused_element')); return; }
       var labf = (aef.dataset && aef.dataset.navableLabel) || aef.getAttribute && aef.getAttribute('aria-label') || aef.innerText || aef.textContent || '';
       labf = String(labf || '').trim();
       try { aef.click(); } catch (_err) { /* click failed */ }
-      speak('Activated ' + (labf || 'element'));
+      speak(translate('activated_value', { value: labf || translate('target_element') }));
       console.log('[Navable] Action: activate focused');
       return;
     }
     if (cmd.type === 'activate' && cmd.target === 'button' && cmd.label) {
       var ab = findByLabel('button', cmd.label);
-      if (!ab) { speak('I did not find that button.'); return; }
+      if (!ab) { speak(translate('not_found_button')); return; }
       var labb = ab.dataset.navableLabel || ab.innerText || ab.textContent || '';
       try { ab.focus(); } catch (_err) { /* focus failed */ }
       try { ab.click(); } catch (_err) { /* click failed */ }
-      speak('Activated ' + (String(labb || 'button').trim()));
+      speak(translate('activated_value', { value: String(labb || translate('target_button')).trim() }));
       console.log('[Navable] Action: activate button by label', cmd.label);
       return;
     }
     if (cmd.type === 'activate' && cmd.target === 'button' && cmd.n != null) {
       var abin = pickNth('button', cmd.n);
-      if (!abin) { speak('I did not find a button.'); return; }
+      if (!abin) { speak(translate('not_found_generic', { target: localizeTarget('button') })); return; }
       var labbn = abin.dataset.navableLabel || abin.innerText || abin.textContent || '';
       try { abin.focus(); } catch (_err) { /* focus failed */ }
       try { abin.click(); } catch (_err) { /* click failed */ }
-      speak('Activated ' + (String(labbn || 'button').trim()));
+      speak(translate('activated_value', { value: String(labbn || translate('target_button')).trim() }));
       console.log('[Navable] Action: activate button', cmd.n);
       return;
     }
     if (cmd.type === 'move' && (cmd.target === 'link' || cmd.target === 'button')) {
       var elmv = moveBy(cmd.target, cmd.dir === 'prev' ? 'prev' : 'next');
-      if (!elmv) { speak('I did not find a ' + cmd.target + '.'); return; }
+      if (!elmv) { speak(translate('not_found_generic', { target: localizeTarget(cmd.target) })); return; }
       try { elmv.focus(); } catch (_err) { /* focus failed */ }
       var lblmv = elmv.dataset.navableLabel || elmv.innerText || elmv.textContent || '';
-      speak('Focused ' + (lblmv.trim() || cmd.target));
+      speak(translate('focused_value', { value: lblmv.trim() || localizeTarget(cmd.target) }));
       console.log('[Navable] Action: move ' + cmd.target, cmd.dir);
       return;
     }
     if (cmd.type === 'move' && cmd.target === 'heading') {
       var elmh = moveBy('heading', cmd.dir === 'prev' ? 'prev' : 'next');
-      if (!elmh) { speak('I did not find a heading.'); return; }
+      if (!elmh) { speak(translate('not_found_generic', { target: localizeTarget('heading') })); return; }
       var lblmh = elmh.dataset.navableLabel || elmh.innerText || elmh.textContent || '';
       if (!elmh.hasAttribute('tabindex')) {
         try { elmh.setAttribute('tabindex', '-1'); } catch (_err) { /* ignore */ }
       }
       try { elmh.focus(); } catch (_err) { /* focus failed */ }
-      speak('Heading: ' + (lblmh.trim() || 'unnamed'));
+      speak(translate('heading_value', { value: lblmh.trim() || translate('unnamed') }));
       console.log('[Navable] Action: move heading', cmd.dir);
       return;
     }
@@ -1193,52 +1323,104 @@
 
   async function runSummaryRequest(commandText) {
     var cmdText = (commandText && String(commandText).trim()) || 'Summarize this page';
-    announce('Summarizing this page… please wait.', { mode: 'assertive', priority: true });
+    announce(translate('summarizing_wait'), {
+      mode: 'assertive',
+      priority: true,
+      lang: outputLocale(currentOutputLanguage())
+    });
     if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) {
-      announce('Sorry — summarization is unavailable on this page.', { mode: 'assertive', priority: true });
+      announce(translate('summarize_unavailable_page'), {
+        mode: 'assertive',
+        priority: true,
+        lang: outputLocale(currentOutputLanguage())
+      });
       return;
     }
     try {
-      var res = await chrome.runtime.sendMessage({ type: 'planner:run', command: cmdText });
+      var res = await chrome.runtime.sendMessage({
+        type: 'planner:run',
+        command: cmdText,
+        outputLanguage: currentOutputLanguage()
+      });
       if (!res || res.ok !== true) {
-        announce((res && res.error) ? String(res.error) : 'Sorry — I could not summarize this page.', { mode: 'assertive', priority: true });
+        announce((res && res.error) ? String(res.error) : translate('summarize_failed'), {
+          mode: 'assertive',
+          priority: true,
+          lang: outputLocale(currentOutputLanguage())
+        });
       }
       // On success, the background will announce the summary via the live region.
     } catch (err) {
       console.warn('[Navable] summarize via planner failed', err);
-      announce('Sorry — the summary request failed. Please try again.', { mode: 'assertive', priority: true });
+      announce(translate('summarize_request_failed'), {
+        mode: 'assertive',
+        priority: true,
+        lang: outputLocale(currentOutputLanguage())
+      });
     }
   }
 
   async function openSiteRequest(query, newTab) {
     var q = String(query || '').trim();
     if (!q) {
-      speak('Tell me which website to open.');
+      speak(translate('tell_website_to_open'));
       return;
     }
     if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) {
-      speak('Opening a website is unavailable.');
+      speak(translate('open_site_unavailable'));
       return;
     }
     try {
-      var res = await chrome.runtime.sendMessage({ type: 'navable:openSite', query: q, newTab: newTab !== false });
+      var res = await chrome.runtime.sendMessage({
+        type: 'navable:openSite',
+        query: q,
+        newTab: newTab !== false,
+        outputLanguage: currentOutputLanguage()
+      });
       if (!res || res.ok !== true) {
-        speak((res && res.error) ? String(res.error) : 'Could not open that site.');
+        speak((res && res.error) ? String(res.error) : translate('open_site_failed'));
       }
     } catch (err) {
       console.warn('[Navable] open site via background failed', err);
-      speak('Could not open that site.');
+      speak(translate('open_site_failed'));
     }
   }
 
-  function handleTranscript(text) {
+  async function tryIntentFallback(commandText) {
+    if (!chrome || !chrome.runtime || !chrome.runtime.sendMessage) return false;
+    try {
+      var res = await chrome.runtime.sendMessage({
+        type: 'planner:run',
+        command: commandText,
+        outputLanguage: currentOutputLanguage(),
+        preferIntentFallback: true
+      });
+      return !!(res && res.ok === true && (
+        (res.plan && res.plan.steps && res.plan.steps.length) ||
+        res.description ||
+        res.summary
+      ));
+    } catch (err) {
+      console.warn('[Navable] intent fallback failed', err);
+      return false;
+    }
+  }
+
+  async function handleTranscript(text, detectedLanguage) {
     console.log('[Navable] Recognized:', text);
+    setOutputLanguageFromTranscript(text, detectedLanguage);
+    await ensureOutputLanguageReady();
     var cmd = parseCommand(text);
     if (cmd && cmd.type === 'summarize') {
-      runSummaryRequest(cmd.command);
+      await runSummaryRequest(cmd.command);
       return;
     }
-    execCommand(cmd);
+    if (cmd) {
+      execCommand(cmd);
+      return;
+    }
+    if (await tryIntentFallback(text)) return;
+    execCommand(null);
   }
 
   // Hotkey to toggle listening: Alt+Shift+M (prototype)
@@ -1266,6 +1448,7 @@
 	        settings = { language: s.language || 'en-US', overlay: !!s.overlay, autostart: autostart };
 	        settingsLoaded = true;
 	        recogLang = settings.language || 'en-US';
+	        outputLanguage = normalizeOutputLanguage(settings.language || 'en-US');
 	        if (settings.overlay) { overlayOn = true; drawOverlay(); } else { overlayOn = false; clearOverlay(); }
 	        syncListening({ announce: false });
 	      });
@@ -1276,6 +1459,7 @@
 	        settings = { language: s2.language || 'en-US', overlay: !!s2.overlay, autostart: autostart2 };
 	        settingsLoaded = true;
 	        recogLang = settings.language || 'en-US';
+	        outputLanguage = normalizeOutputLanguage(settings.language || 'en-US');
 	        if (settings.overlay) { overlayOn = true; drawOverlay(); } else { overlayOn = false; clearOverlay(); }
 	        syncListening({ announce: false });
 	      });
@@ -1284,7 +1468,7 @@
 
   // Help voice command + hotkey
   function speakHelp() {
-    speak('Try: summarize this page, scroll down, read title, next heading, open first link, activate focused, read selection. Press Alt+Shift+M to toggle listening.');
+    speak(translate('help_examples'));
   }
 
   document.addEventListener('keydown', function (e) {

--- a/src/newtab/newtab.html
+++ b/src/newtab/newtab.html
@@ -92,6 +92,7 @@
       </footer>
     </main>
 
+    <script src="../common/i18n.js"></script>
     <script src="../common/announce.js"></script>
     <script src="../common/speech.js"></script>
     <script src="newtab.js"></script>

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -74,11 +74,61 @@ function announce(text, mode = 'polite') {
   if (!msg) return;
   try {
     if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
-      window.NavableAnnounce.speak(msg, { mode: mode === 'assertive' ? 'assertive' : 'polite' });
+      window.NavableAnnounce.speak(msg, {
+        mode: mode === 'assertive' ? 'assertive' : 'polite',
+        lang: outputLocale(currentOutputLanguage())
+      });
     }
   } catch (_err) {
     // ignore
   }
+}
+
+const i18n = window.NavableI18n || null;
+
+function normalizeOutputLanguage(lang) {
+  if (i18n && typeof i18n.normalizeLanguage === 'function') return i18n.normalizeLanguage(lang);
+  return String(lang || 'en').toLowerCase().split(/[-_]/)[0] || 'en';
+}
+
+function outputLocale(lang) {
+  if (i18n && typeof i18n.localeForLanguage === 'function') return i18n.localeForLanguage(lang);
+  return String(lang || 'en-US');
+}
+
+function currentOutputLanguage() {
+  return normalizeOutputLanguage(newtabOutputLanguage || newtabVoiceLang || 'en-US');
+}
+
+function translate(key, params, lang) {
+  const resolved = normalizeOutputLanguage(lang || currentOutputLanguage());
+  if (i18n && typeof i18n.t === 'function') return i18n.t(key, resolved, params);
+  return key;
+}
+
+function ensureOutputLanguageReady(lang) {
+  const resolved = normalizeOutputLanguage(lang || currentOutputLanguage());
+  if (i18n && typeof i18n.ensureLanguage === 'function') return i18n.ensureLanguage(resolved);
+  return Promise.resolve();
+}
+
+function resolveTranscriptLanguage(text) {
+  if (i18n && typeof i18n.resolveOutputLanguage === 'function') {
+    return i18n.resolveOutputLanguage({
+      transcript: text,
+      fallbackLanguage: currentOutputLanguage()
+    });
+  }
+  return currentOutputLanguage();
+}
+
+function setNewtabOutputLanguage(transcript, detectedLanguage) {
+  if (detectedLanguage) {
+    newtabOutputLanguage = normalizeOutputLanguage(detectedLanguage);
+    return newtabOutputLanguage;
+  }
+  newtabOutputLanguage = resolveTranscriptLanguage(transcript);
+  return newtabOutputLanguage;
 }
 
 function isVoiceSupported() {
@@ -100,15 +150,26 @@ function extractOpenSiteQuery(transcript) {
   const s = String(transcript || '').trim().toLowerCase();
   if (!s) return null;
 
-  // Arabic: "افتح <شيء>"
-  const ar = s.match(/^افتح\s+(.+)$/);
-  if (ar && ar[1]) return String(ar[1]).trim();
+  // Arabic website intents.
+  const ar = s.match(/^(افتح|اذهب\s+إلى|اذهب\s+الى|روح\s+على|روح\s+إلى|روح\s+الى|انتقل\s+إلى|انتقل\s+الى)\s+(.+)$/);
+  if (ar && ar[2]) return String(ar[2]).trim();
 
-  // English: "open (me) <site>"
-  if (!/^(open|navigate to|go to|take me to)\b/.test(s)) return null;
+  // French website intents.
+  const fr = s.match(/^(ouvre|va(?:s)?\s+(?:a|à)|aller?\s+(?:a|à)|visite|lance)\s+(.+)$/);
+  if (fr && fr[2]) {
+    return String(fr[2])
+      .trim()
+      .replace(/^(le|la|les|un|une)\b/, '')
+      .trim()
+      .replace(/^(site|page|onglet)\b/, '')
+      .trim();
+  }
+
+  // English: flexible website intents.
+  if (!/^(open|navigate to|go to|take me to|visit|bring up|launch)\b/.test(s)) return null;
 
   const q = s
-    .replace(/^(open(\s+up)?|navigate to|go to|take me to)\b/, '')
+    .replace(/^(open(\s+up)?|navigate to|go to|take me to|visit|bring up|launch)\b/, '')
     .trim()
     .replace(/^(me|for me)\b/, '')
     .trim()
@@ -124,23 +185,40 @@ function extractOpenSiteQuery(transcript) {
   return q || null;
 }
 
+function extractSearchQuery(transcript) {
+  const s = String(transcript || '').trim().toLowerCase();
+  if (!s) return null;
+
+  const en = s.match(/^(search|google|look up|find)\s+(for\s+)?(.+)$/);
+  if (en && en[3]) return `search for ${String(en[3]).trim()}`;
+
+  const fr = s.match(/^(cherche|recherche)\s+(.+)$/);
+  if (fr && fr[2]) return `search for ${String(fr[2]).trim()}`;
+
+  const ar = s.match(/^(ابحث|فتش)(\s+عن)?\s+(.+)$/);
+  if (ar && ar[3]) return `search for ${String(ar[3]).trim()}`;
+
+  return null;
+}
+
 function parseVoiceCommand(transcript) {
   const t = String(transcript || '').trim();
   const low = t.toLowerCase();
   if (!low) return null;
 
-  if (/^(help|commands|show commands|what can i say\??)$/.test(low) || /مساعدة/.test(low)) {
+  if (
+    /^(help|commands|show commands|what can i say\??|aide|montre les commandes|que puis-je dire\??)$/.test(low) ||
+    /مساعدة/.test(low)
+  ) {
     return { type: 'help' };
   }
 
-  if (/^(stop|stop listening|cancel)$/.test(low)) {
+  if (/^(stop|stop listening|cancel|arr[êe]te|stoppe|توقف|قف)$/.test(low)) {
     return { type: 'stop' };
   }
 
-  const searchMatch = low.match(/^(search|google)\s+(for\s+)?(.+)$/);
-  if (searchMatch && searchMatch[3]) {
-    return { type: 'open_site', query: `search for ${searchMatch[3]}` };
-  }
+  const searchQuery = extractSearchQuery(low);
+  if (searchQuery) return { type: 'open_site', query: searchQuery };
 
   const q = extractOpenSiteQuery(t);
   if (q) return { type: 'open_site', query: q };
@@ -152,6 +230,7 @@ let newtabRecognizer = null;
 let newtabWantsListening = false;
 let newtabVoiceReady = false;
 let newtabVoiceLang = 'en-US';
+let newtabOutputLanguage = 'en';
 
 function refreshNewtabMicUi() {
   const { btn, status } = getVoiceStatusEls();
@@ -204,6 +283,7 @@ async function ensureNewtabRecognizer() {
 
   const settings = await loadNewtabVoiceSettings();
   newtabVoiceLang = settings.language || 'en-US';
+  newtabOutputLanguage = normalizeOutputLanguage(newtabVoiceLang);
 
   try {
     newtabRecognizer = window.NavableSpeech.createRecognizer({
@@ -215,7 +295,7 @@ async function ensureNewtabRecognizer() {
 
     newtabRecognizer.on('result', (ev) => {
       if (!ev?.transcript) return;
-      handleNewtabTranscript(ev.transcript);
+      handleNewtabTranscript(ev.transcript, ev.language || '');
     });
 
     newtabRecognizer.on('error', (e) => {
@@ -225,23 +305,23 @@ async function ensureNewtabRecognizer() {
       if (code === 'not-allowed' || code === 'service-not-allowed') {
         newtabWantsListening = false;
         refreshNewtabMicUi();
-        setNewtabMicMessage('Microphone access is blocked. Allow microphone for this extension to use voice.', 'assertive');
+        setNewtabMicMessage(translate('mic_access_blocked'), 'assertive');
         return;
       }
 
       if (code === 'audio-capture' || code === 'aborted' || code === 'start-failed') {
-        setNewtabMicMessage('Microphone is busy. Close other apps/tabs using the mic, then try again.', 'polite');
+        setNewtabMicMessage(translate('mic_busy'), 'polite');
         return;
       }
 
       if (code === 'network') {
         newtabWantsListening = false;
         refreshNewtabMicUi();
-        setNewtabMicMessage('Speech recognition is unavailable due to a network issue.', 'assertive');
+        setNewtabMicMessage(translate('speech_network_issue'), 'assertive');
         return;
       }
 
-      setNewtabMicMessage('Speech recognition had a problem. Please try again.', 'assertive');
+      setNewtabMicMessage(translate('speech_problem_retry'), 'assertive');
     });
 
     newtabRecognizer.on('start', () => {
@@ -265,9 +345,14 @@ async function openSiteFromVoice(query) {
 
   try {
     if (chrome?.runtime?.sendMessage) {
-      const res = await chrome.runtime.sendMessage({ type: 'navable:openSite', query: q, newTab: false });
+      const res = await chrome.runtime.sendMessage({
+        type: 'navable:openSite',
+        query: q,
+        newTab: false,
+        outputLanguage: currentOutputLanguage()
+      });
       if (res?.ok) return;
-      setNewtabMicMessage(res?.error || 'Could not open that website.', 'assertive');
+      setNewtabMicMessage(res?.error || translate('open_site_failed'), 'assertive');
       return;
     }
   } catch (_err) {
@@ -276,21 +361,23 @@ async function openSiteFromVoice(query) {
 
   const url = resolveQueryToUrl(q);
   if (!url) {
-    setNewtabMicMessage('Missing website name or URL.', 'assertive');
+    setNewtabMicMessage(translate('missing_url'), 'assertive');
     return;
   }
   await openUrl(url);
 }
 
-async function handleNewtabTranscript(transcript) {
+async function handleNewtabTranscript(transcript, detectedLanguage) {
+  setNewtabOutputLanguage(transcript, detectedLanguage);
+  await ensureOutputLanguageReady();
   const cmd = parseVoiceCommand(transcript);
   if (!cmd) {
-    setNewtabMicMessage('I did not catch that. Try: “Open YouTube”.', 'polite');
+    setNewtabMicMessage(translate('newtab_try_open'), 'polite');
     return;
   }
 
   if (cmd.type === 'help') {
-    setNewtabMicMessage('Try: “Open YouTube”, “Open example dot com”, “Search for weather”.', 'assertive');
+    setNewtabMicMessage(translate('newtab_help_examples'), 'assertive');
     return;
   }
 
@@ -300,7 +387,7 @@ async function handleNewtabTranscript(transcript) {
   }
 
   if (cmd.type === 'open_site') {
-    setNewtabMicMessage(`Opening ${cmd.query}…`, 'assertive');
+    setNewtabMicMessage(translate('opening_site', { value: cmd.query }), 'assertive');
     await openSiteFromVoice(cmd.query);
   }
 }
@@ -314,12 +401,12 @@ async function startNewtabListening() {
     newtabWantsListening = false;
     newtabVoiceReady = true;
     refreshNewtabMicUi();
-    setNewtabMicMessage('Voice input is not available in this browser.', 'assertive');
+    setNewtabMicMessage(translate('voice_unavailable_browser'), 'assertive');
     return;
   }
 
   recognizer.start();
-  setNewtabMicMessage('Listening… Say “Open YouTube”.', 'polite');
+  setNewtabMicMessage(translate('newtab_listening'), 'polite');
 }
 
 function stopNewtabListening(opts = {}) {
@@ -330,7 +417,7 @@ function stopNewtabListening(opts = {}) {
   } catch (_err) {
     // ignore
   }
-  if (opts.announce) setNewtabMicMessage('Stopped listening.', 'polite');
+  if (opts.announce) setNewtabMicMessage(translate('stopped_listening'), 'polite');
 }
 
 async function toggleNewtabListening() {
@@ -386,7 +473,7 @@ function wireNewtabVoice() {
   if (!isVoiceSupported()) {
     const { btn: btn2 } = getVoiceStatusEls();
     if (btn2) btn2.disabled = true;
-    setNewtabMicMessage('Voice input is not available in this browser.', 'polite');
+    setNewtabMicMessage(translate('voice_unavailable_browser'), 'polite');
   }
 }
 

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -24,7 +24,7 @@
               <div>
                 <h1 class="nv-options-title">Navable settings</h1>
                 <p class="nv-options-subtitle">
-                  Tune voice language, continuous listening, and AI summarization—without changing any of Navable’s core behavior.
+                  Tune voice fallback language, continuous listening, and AI features without changing Navable’s navigation behavior.
                 </p>
               </div>
             </div>
@@ -41,7 +41,7 @@
             <h2>Voice settings</h2>
             <div class="nv-form-grid">
               <div class="nv-field">
-                <label class="nv-label" for="language">Language</label>
+                <label class="nv-label" for="language">Fallback language</label>
                 <select id="language" class="nv-select">
                   <option value="en-US">English (United States)</option>
                   <option value="en-GB">English (United Kingdom)</option>
@@ -53,7 +53,7 @@
                 <span>Continuous listening (auto-start on pages)</span>
               </label>
             </div>
-            <p>Navable uses the browser’s built-in Web Speech API. Continuous listening may not be available on all sites.</p>
+            <p>Navable prefers backend multilingual transcription for automatic language detection, and falls back to the browser speech API if the backend is unavailable.</p>
           </div>
         </section>
 
@@ -85,7 +85,7 @@
                 <span>Do not summarize on sensitive sites</span>
               </label>
             </div>
-            <p>AI is only called when you explicitly run a “Summarize” command from the popup.</p>
+            <p>AI summaries are on-demand. Voice transcription may also use the backend when multilingual command recognition is available.</p>
           </div>
         </section>
 
@@ -110,8 +110,8 @@
             <h2>Privacy</h2>
             <p>
               Navable collects a structured snapshot of the current page (titles, headings, links, buttons, and non-sensitive form field
-              labels). It <strong>does not</strong> collect passwords, credit card fields, or raw audio. When AI summarization is enabled,
-              this snapshot may be sent to your configured backend for summarization, and only when you ask Navable to summarize the page.
+              labels). It <strong>does not</strong> collect passwords or credit card fields. Short microphone clips for spoken commands may
+              be sent to your configured backend for transcription, and page snapshots may be sent for summarization when those features are enabled.
             </p>
           </div>
         </section>

--- a/tests/flexible-intent.spec.ts
+++ b/tests/flexible-intent.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+test('planner fallback handles looser navigation phrasing', async ({ page }) => {
+  await page.setContent(`
+    <main style="height: 2400px">
+      <h1>Home</h1>
+      <p>Intro copy.</p>
+      <a id="pricing-link" href="#pricing">Pricing</a>
+      <div style="height: 1400px"></div>
+      <h2 id="pricing" tabindex="-1">Pricing</h2>
+      <p>Plans and billing.</p>
+    </main>
+  `);
+
+  await page.addScriptTag({ path: 'src/background.js' });
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+  await page.addScriptTag({ path: 'src/common/speech.js' });
+  await page.addScriptTag({ path: 'src/content.js' });
+
+  await page.waitForFunction(() => (window as any).NavableTools?.buildPageStructure);
+
+  const scrollResult = await page.evaluate(async () => {
+    // @ts-ignore
+    return await (window as any).runPlanner('take me a bit lower', 'en', true);
+  });
+  expect(scrollResult.ok).toBe(true);
+  await page.waitForFunction(() => window.scrollY > 0);
+
+  const pricingResult = await page.evaluate(async () => {
+    // @ts-ignore
+    return await (window as any).runPlanner('take me to pricing', 'en', true);
+  });
+  expect(pricingResult.ok).toBe(true);
+  await page.waitForFunction(() => window.location.hash === '#pricing');
+});
+
+test('planner fallback understands French and Arabic intent phrases', async ({ page }) => {
+  await page.setContent(`
+    <main style="height: 2400px">
+      <h1>Accueil</h1>
+      <p>Bienvenue.</p>
+      <div style="height: 1200px"></div>
+      <h2 id="features">Features</h2>
+      <h2 id="pricing">Pricing</h2>
+    </main>
+  `);
+
+  await page.addScriptTag({ path: 'src/background.js' });
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+  await page.addScriptTag({ path: 'src/common/speech.js' });
+  await page.addScriptTag({ path: 'src/content.js' });
+
+  await page.waitForFunction(() => (window as any).NavableTools?.buildPageStructure);
+
+  const frenchScroll = await page.evaluate(async () => {
+    // @ts-ignore
+    return await (window as any).runPlanner('descends un peu', 'fr', true);
+  });
+  expect(frenchScroll.ok).toBe(true);
+  await page.waitForFunction(() => window.scrollY > 0);
+
+  const arabicHeading = await page.evaluate(async () => {
+    document.body.focus();
+    // @ts-ignore
+    return await (window as any).runPlanner('العنوان التالي', 'ar', true);
+  });
+  expect(arabicHeading.ok).toBe(true);
+  await page.waitForFunction(() => document.activeElement && document.activeElement.tagName === 'H2');
+});

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+
+test('language helper resolves transcript language and explicit overrides', async ({ page }) => {
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+
+  const result = await page.evaluate(() => {
+    // @ts-ignore
+    const i18n = (window as any).NavableI18n;
+    return {
+      frenchTranscript: i18n.resolveOutputLanguage({ transcript: 'Ouvre YouTube', fallbackLanguage: 'en-US' }),
+      explicitFrench: i18n.resolveOutputLanguage({ transcript: 'Summarize this page in French', fallbackLanguage: 'en-US' }),
+      arabicTranscript: i18n.resolveOutputLanguage({ transcript: 'افتح يوتيوب', fallbackLanguage: 'en-US' }),
+      frenchMessage: i18n.t('scrolled_down', 'fr'),
+      frenchLocale: i18n.localeForLanguage('fr')
+    };
+  });
+
+  expect(result.frenchTranscript).toBe('fr');
+  expect(result.explicitFrench).toBe('fr');
+  expect(result.arabicTranscript).toBe('ar');
+  expect(result.frenchMessage).toContain('Defilement');
+  expect(result.frenchLocale).toBe('fr-FR');
+});
+
+test('language helper loads an on-demand pack for unknown languages', async ({ page }) => {
+  await page.evaluate(() => {
+    window.fetch = async (_url, init) => {
+      const body = JSON.parse(String(init?.body || '{}'));
+      return {
+        ok: true,
+        async json() {
+          return {
+            language: body.language,
+            messages: {
+              ...body.messages,
+              scrolled_down: 'Desplazado hacia abajo.'
+            }
+          };
+        }
+      };
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+
+  const result = await page.evaluate(async () => {
+    // @ts-ignore
+    const i18n = (window as any).NavableI18n;
+    await i18n.ensureLanguage('es');
+    return {
+      message: i18n.t('scrolled_down', 'es'),
+      locale: i18n.localeForLanguage('es')
+    };
+  });
+
+  expect(result.message).toBe('Desplazado hacia abajo.');
+  expect(result.locale).toBe('es');
+});
+
+test('announce helper applies lang attribute to live regions', async ({ page }) => {
+  await page.setContent('<main><h1>Test</h1></main>');
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+
+  await page.evaluate(() => {
+    // @ts-ignore
+    (window as any).NavableAnnounce.speak('Bonjour', { mode: 'polite', lang: 'fr-FR' });
+  });
+
+  const region = page.locator('#navable-live-region-polite');
+  await expect(region).toHaveAttribute('lang', 'fr-FR');
+  await expect(region).toHaveText(/Bonjour/, { timeout: 5000 });
+});
+
+test('background fallback orientation follows output language', async ({ page }) => {
+  await page.addScriptTag({ path: 'src/background.js' });
+
+  const description = await page.evaluate(() => {
+    // @ts-ignore
+    return (window as any).buildFriendlyOrientation(
+      {
+        title: 'Example',
+        counts: { headings: 2, links: 4, buttons: 1 },
+        headings: [{ label: 'Accueil' }],
+        excerpt: 'Bonjour et bienvenue sur cette page.'
+      },
+      'fr'
+    );
+  });
+
+  expect(description).toContain('Titre');
+  expect(description).toContain('liens');
+  expect(description).toContain('Titre principal');
+});

--- a/tests/open-site.spec.ts
+++ b/tests/open-site.spec.ts
@@ -18,18 +18,23 @@ test('openSiteInBrowser resolves a single token to a .com URL', async ({ page })
   expect(created).toContain(res.url);
 });
 
-test('resolveOpenQueryToUrl supports spoken dot/slash and search fallback', async ({ page }) => {
+test('resolveOpenQueryToUrl supports spoken dot/slash, multilingual site aliases, and direct-open preference', async ({ page }) => {
   await page.addScriptTag({ path: 'src/background.js' });
 
   const urls = await page.evaluate(() => {
     // @ts-ignore
     return {
       login: (window as any).resolveOpenQueryToUrl('example dot com slash login'),
-      search: (window as any).resolveOpenQueryToUrl('stack overflow')
+      arabicYoutube: (window as any).resolveOpenQueryToUrl('يوتيوب'),
+      knownAlias: (window as any).resolveOpenQueryToUrl('stack overflow'),
+      guessedHost: (window as any).resolveOpenQueryToUrl('new york times'),
+      genericHost: (window as any).resolveOpenQueryToUrl('weather tomorrow')
     };
   });
 
   expect(urls.login).toBe('https://example.com/login');
-  expect(urls.search).toContain('https://www.google.com/search?q=');
+  expect(urls.arabicYoutube).toBe('https://www.youtube.com/');
+  expect(urls.knownAlias).toBe('https://stackoverflow.com/');
+  expect(urls.guessedHost).toBe('https://www.newyorktimes.com/');
+  expect(urls.genericHost).toBe('https://www.weathertomorrow.com/');
 });
-

--- a/tests/speech-engine.spec.ts
+++ b/tests/speech-engine.spec.ts
@@ -1,0 +1,302 @@
+import { expect, test } from '@playwright/test';
+
+test('speech engine uses backend transcription when available', async ({ page }) => {
+  await page.setContent('<main>Speech test</main>');
+
+  await page.evaluate(() => {
+    let analyserReads = 0;
+
+    class FakeAudioContext {
+      createMediaStreamSource() {
+        return { connect() {}, disconnect() {} };
+      }
+      createAnalyser() {
+        return {
+          fftSize: 2048,
+          smoothingTimeConstant: 0.1,
+          connect() {},
+          disconnect() {},
+          getByteTimeDomainData(arr: Uint8Array) {
+            analyserReads += 1;
+            const sample = analyserReads <= 3 ? 160 : 128;
+            for (let i = 0; i < arr.length; i += 1) arr[i] = sample;
+          }
+        };
+      }
+      resume() {
+        return Promise.resolve();
+      }
+      close() {
+        return Promise.resolve();
+      }
+    }
+
+    class FakeMediaRecorder {
+      static isTypeSupported() {
+        return true;
+      }
+
+      state = 'inactive';
+      mimeType = 'audio/webm';
+      ondataavailable: ((ev: any) => void) | null = null;
+      onstop: (() => void) | null = null;
+      onerror: ((ev: any) => void) | null = null;
+
+      start() {
+        this.state = 'recording';
+      }
+
+      stop() {
+        this.state = 'inactive';
+        if (this.ondataavailable) {
+          this.ondataavailable({ data: new Blob(['voice'], { type: 'audio/webm' }) });
+        }
+        if (this.onstop) this.onstop();
+      }
+    }
+
+    // @ts-ignore
+    window.__NavableSpeechEnv = {
+      fetch: async (url: string) => {
+        if (String(url).endsWith('/health')) {
+          return new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+        return new Response(JSON.stringify({ text: 'ouvre youtube', language: 'fr' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      },
+      mediaDevices: {
+        getUserMedia() {
+          return Promise.resolve({
+            getTracks() {
+              return [{ stop() {} }];
+            }
+          });
+        }
+      },
+      AudioContext: FakeAudioContext,
+      MediaRecorder: FakeMediaRecorder
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/common/speech.js' });
+
+  const result = await page.evaluate(async () => {
+    // @ts-ignore
+    const recognizer = window.NavableSpeech.createRecognizer({
+      silenceMs: 20,
+      minSpeechMs: 5,
+      checkIntervalMs: 10
+    });
+    return await new Promise((resolve) => {
+      recognizer.on('result', (ev: any) => {
+        recognizer.stop();
+        resolve({ transcript: ev.transcript, language: ev.language, provider: ev.provider });
+      });
+      recognizer.on('error', (ev: any) => resolve({ error: ev.error, provider: ev.provider }));
+      recognizer.start();
+    });
+  });
+
+  expect(result).toEqual({ transcript: 'ouvre youtube', language: 'fr', provider: 'backend' });
+});
+
+test('speech engine falls back to native recognition when backend is unavailable', async ({ page }) => {
+  await page.setContent('<main>Speech fallback test</main>');
+
+  await page.evaluate(() => {
+    class FakeRecognition {
+      lang = 'en-US';
+      interimResults = false;
+      continuous = true;
+      onresult: ((ev: any) => void) | null = null;
+      onerror: ((ev: any) => void) | null = null;
+      onstart: (() => void) | null = null;
+      onend: (() => void) | null = null;
+
+      start() {
+        if (this.onstart) this.onstart();
+        setTimeout(() => {
+          if (this.onresult) {
+            this.onresult({
+              resultIndex: 0,
+              results: [
+                { 0: { transcript: 'open youtube' }, isFinal: true }
+              ]
+            });
+          }
+        }, 10);
+      }
+
+      stop() {
+        if (this.onend) this.onend();
+      }
+    }
+
+    // @ts-ignore
+    window.__NavableSpeechEnv = {
+      fetch: async () =>
+        new Response(JSON.stringify({ error: 'offline' }), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' }
+        }),
+      SpeechRecognition: FakeRecognition
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/common/speech.js' });
+
+  const result = await page.evaluate(async () => {
+    // @ts-ignore
+    const recognizer = window.NavableSpeech.createRecognizer({ checkIntervalMs: 10 });
+    return await new Promise((resolve) => {
+      recognizer.on('result', (ev: any) => {
+        recognizer.stop();
+        resolve({ transcript: ev.transcript, provider: ev.provider });
+      });
+      recognizer.on('error', (ev: any) => resolve({ error: ev.error, provider: ev.provider }));
+      recognizer.start();
+    });
+  });
+
+  expect(result).toEqual({ transcript: 'open youtube', provider: 'native' });
+});
+
+test('speech engine falls back to native recognition when backend returns no speech', async ({ page }) => {
+  await page.setContent('<main>Speech fallback test</main>');
+
+  await page.evaluate(() => {
+    let requestCount = 0;
+    let analyserReads = 0;
+
+    class FakeAudioContext {
+      createMediaStreamSource() {
+        return { connect() {}, disconnect() {} };
+      }
+      createAnalyser() {
+        return {
+          fftSize: 2048,
+          smoothingTimeConstant: 0.1,
+          connect() {},
+          disconnect() {},
+          getByteTimeDomainData(arr: Uint8Array) {
+            analyserReads += 1;
+            const sample = analyserReads <= 3 ? 160 : 128;
+            for (let i = 0; i < arr.length; i += 1) arr[i] = sample;
+          }
+        };
+      }
+      resume() {
+        return Promise.resolve();
+      }
+      close() {
+        return Promise.resolve();
+      }
+    }
+
+    class FakeMediaRecorder {
+      static isTypeSupported() {
+        return true;
+      }
+
+      state = 'inactive';
+      mimeType = 'audio/webm';
+      ondataavailable: ((ev: any) => void) | null = null;
+      onstop: (() => void) | null = null;
+
+      start() {
+        this.state = 'recording';
+      }
+
+      stop() {
+        this.state = 'inactive';
+        if (this.ondataavailable) {
+          this.ondataavailable({ data: new Blob(['voice'], { type: 'audio/webm' }) });
+        }
+        if (this.onstop) this.onstop();
+      }
+    }
+
+    class FakeRecognition {
+      lang = 'en-US';
+      interimResults = false;
+      continuous = true;
+      onresult: ((ev: any) => void) | null = null;
+      onerror: ((ev: any) => void) | null = null;
+      onstart: (() => void) | null = null;
+      onend: (() => void) | null = null;
+
+      start() {
+        if (this.onstart) this.onstart();
+        setTimeout(() => {
+          if (this.onresult) {
+            this.onresult({
+              resultIndex: 0,
+              results: [
+                { 0: { transcript: 'open youtube' }, isFinal: true }
+              ]
+            });
+          }
+        }, 10);
+      }
+
+      stop() {
+        if (this.onend) this.onend();
+      }
+    }
+
+    // @ts-ignore
+    window.__NavableSpeechEnv = {
+      fetch: async (url: string) => {
+        if (String(url).endsWith('/health')) {
+          return new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+        requestCount += 1;
+        return new Response(JSON.stringify({ text: '', language: '' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      },
+      mediaDevices: {
+        getUserMedia() {
+          return Promise.resolve({
+            getTracks() {
+              return [{ stop() {} }];
+            }
+          });
+        }
+      },
+      AudioContext: FakeAudioContext,
+      MediaRecorder: FakeMediaRecorder,
+      SpeechRecognition: FakeRecognition
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/common/speech.js' });
+
+  const result = await page.evaluate(async () => {
+    // @ts-ignore
+    const recognizer = window.NavableSpeech.createRecognizer({
+      silenceMs: 20,
+      minSpeechMs: 5,
+      checkIntervalMs: 10
+    });
+    return await new Promise((resolve) => {
+      recognizer.on('result', (ev: any) => {
+        recognizer.stop();
+        resolve({ transcript: ev.transcript, provider: ev.provider });
+      });
+      recognizer.on('error', (ev: any) => resolve({ error: ev.error, provider: ev.provider }));
+      recognizer.start();
+    });
+  });
+
+  expect(result).toEqual({ transcript: 'open youtube', provider: 'native' });
+});


### PR DESCRIPTION
Summary
This PR improves Navable’s voice stack in two focused layers:

Multilingual voice recognition and Navable-authored output localization
More flexible intent resolution, especially for direct website opening
The goal is to make Navable behave more naturally when users speak in different languages, while reducing cases where open ... falls back to a generic Google results page instead of opening the intended site.

What Changed
1. Multilingual voice recognition and output localization
This part introduces a backend-first speech flow with browser fallback and a shared localization layer for Navable’s own responses.

Highlights:

Adds a shared i18n module for Navable-authored messages
Preserves detected output languages instead of collapsing unknown languages to English
Supports lazy loading of translated UI message packs from the backend
Updates content and new tab speech flows to wait for the correct output language pack before replying
Uses locale-aware live-region announcements for better screen reader pronunciation
Adds backend endpoints and schema updates for:
multilingual transcription
translated message catalogs
Improves speech robustness by:
starting backend recording immediately when listening begins
falling back to browser recognition when backend transcription is unavailable
falling back to browser recognition when backend transcription returns no-speech
Primary commit:

6bd4145 feat(voice): add multilingual speech recognition and output localization
2. More flexible intent routing and direct site opening
This part broadens the planner and open-site resolver so user intent is interpreted more naturally across English, French, and Arabic.

Highlights:

Expands background planner heuristics for:
page orientation
scroll/navigation phrasing
focused-element reads
heading movement
labeled target selection
Localizes background-originated planner and summary announcements
Passes output-language preferences through planner and open-site flows
Adds multilingual site aliases for common destinations such as:
YouTube
X/Twitter
Stack Overflow
ChatGPT
and other common sites
Changes open ... behavior to prefer direct navigation:
known aliases open the actual site
unresolved brand-like ASCII phrases try a direct hostname guess
explicit search remains search
plain search-results pages are no longer the default outcome for open intent
Primary commit:

1c34f18 feat(intent): broaden multilingual planner routing and direct site opening
Why
Before this PR:

multilingual behavior was limited and heavily hardcoded
unknown output languages often fell back to English behavior
short spoken commands could be clipped before transcription
open ... could degrade into generic search results too easily
commands like افتح يوتيوب were not reliably routed to the actual website
After this PR:

Navable’s own replies can follow many more languages
speech recognition is more resilient
direct-open intent is stricter and more useful
common multilingual site names resolve to actual websites more reliably
Validation
Ran successfully:

npm run lint
npm test
npm run build
node --check backend/src/server.js
node --check backend/src/openapi.js
Notes
Current behavior intentionally distinguishes:

open ... -> prefer opening a site directly
search ... -> perform a search