### PR TITLE
feat: add session-aware assistant routing and browser open-site actions

### DIFF
--- a/backend/src/assistant-session.js
+++ b/backend/src/assistant-session.js
@@ -1,0 +1,107 @@
+function trimSessionText(text, maxLen = 240) {
+  const raw = String(text || '').replace(/\s+/g, ' ').trim();
+  if (!raw) return '';
+  return raw.length > maxLen ? `${raw.slice(0, Math.max(0, maxLen - 3)).trim()}...` : raw;
+}
+
+function isFollowUpIntentText(text) {
+  const t = String(text || '').trim().toLowerCase();
+  if (!t) return false;
+  return (
+    /^(tell me more|more detail|more details|go on|continue|keep going|expand that|what about that|what about it|and then)\b/.test(t) ||
+    /^(dis[- ]?m[' ]?en plus|plus de d[ée]tails|continue|vas[- ]?y|et ensuite)\b/.test(t) ||
+    /^(احكيلي اكثر|احكيلي المزيد|زيدني|كم[ّ]?ل|كمل|ماذا عن ذلك|شو كمان|ايش كمان)\b/.test(t)
+  );
+}
+
+function rewriteTopicPronouns(text, topic) {
+  const raw = trimSessionText(text, 240);
+  const subject = trimSessionText(topic, 120);
+  if (!raw || !subject) return raw;
+  return raw
+    .replace(/\bits\b/gi, `${subject}'s`)
+    .replace(/\btheir\b/gi, `${subject}'s`)
+    .replace(/\bit\b/gi, subject)
+    .replace(/\bthis\b/gi, subject)
+    .replace(/\bthat\b/gi, subject)
+    .replace(/\bthey\b/gi, subject)
+    .replace(/\bthem\b/gi, subject)
+    .replace(/\bhe\b/gi, subject)
+    .replace(/\bhim\b/gi, subject)
+    .replace(/\bshe\b/gi, subject)
+    .replace(/\bher\b/gi, subject);
+}
+
+function resolveAnswerQuestionWithSessionContext(question, sessionContext = null) {
+  const rawQuestion = trimSessionText(question, 240);
+  if (!rawQuestion) {
+    return { question: '', resolvedQuestion: '', resolvedFromSession: false, topic: '' };
+  }
+
+  const lastEntity = trimSessionText(sessionContext && sessionContext.lastEntity, 120);
+  const lastUserUtterance = trimSessionText(sessionContext && sessionContext.lastUserUtterance, 180);
+  const lastAnswer = trimSessionText(sessionContext && sessionContext.lastAnswer, 220);
+  const isFollowUp = isFollowUpIntentText(rawQuestion);
+
+  if (isFollowUp) {
+    if (lastEntity) {
+      return {
+        question: rawQuestion,
+        resolvedQuestion: `Tell me more about ${lastEntity}.`,
+        resolvedFromSession: true,
+        topic: lastEntity
+      };
+    }
+    if (lastUserUtterance && !isFollowUpIntentText(lastUserUtterance)) {
+      return {
+        question: rawQuestion,
+        resolvedQuestion: `Tell me more about: ${lastUserUtterance}`,
+        resolvedFromSession: true,
+        topic: lastUserUtterance
+      };
+    }
+    if (lastAnswer) {
+      return {
+        question: rawQuestion,
+        resolvedQuestion: `Tell me more about this previous answer: ${lastAnswer}`,
+        resolvedFromSession: true,
+        topic: lastAnswer
+      };
+    }
+  }
+
+  if (lastEntity) {
+    const rewritten = rewriteTopicPronouns(rawQuestion, lastEntity);
+    if (rewritten && rewritten !== rawQuestion) {
+      return {
+        question: rawQuestion,
+        resolvedQuestion: rewritten,
+        resolvedFromSession: true,
+        topic: lastEntity
+      };
+    }
+  }
+
+  return {
+    question: rawQuestion,
+    resolvedQuestion: rawQuestion,
+    resolvedFromSession: false,
+    topic: lastEntity
+  };
+}
+
+function isClarifyingAnswerText(answer) {
+  const t = String(answer || '').trim().toLowerCase();
+  if (!t) return false;
+  return (
+    /\b(specify|clarify|which topic|what topic|which subject|what subject|more context|what would you like|which one)\b/.test(t) ||
+    /(pr[ée]ciser|quel sujet|quel thème|de quel sujet|sur quel sujet)/.test(t) ||
+    /(حدد|حدّد|أي موضوع|اي موضوع|عن ماذا|عن اي موضوع|أي شيء تقصد|اي شيء تقصد)/.test(t)
+  );
+}
+
+export {
+  isClarifyingAnswerText,
+  isFollowUpIntentText,
+  resolveAnswerQuestionWithSessionContext
+};

--- a/backend/src/openapi.js
+++ b/backend/src/openapi.js
@@ -253,6 +253,12 @@ const baseSpec = {
           'Structured snapshot of the page produced by the extension content script.',
         additionalProperties: true
       },
+      SessionContext: {
+        type: 'object',
+        description:
+          'Sanitized short-lived memory for the current tab/session (for example last purpose, last reply, last entity, and page summary hints).',
+        additionalProperties: true
+      },
       Step: {
         type: 'object',
         additionalProperties: false,
@@ -276,6 +282,19 @@ const baseSpec = {
           steps: { type: 'array', items: { $ref: '#/components/schemas/Step' } }
         }
       },
+      AssistantAction: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'query', 'newTab'],
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['open_site']
+          },
+          query: { type: 'string' },
+          newTab: { type: 'boolean' }
+        }
+      },
       AssistantRequest: {
         type: 'object',
         additionalProperties: false,
@@ -294,6 +313,9 @@ const baseSpec = {
             enum: ['auto', 'summary', 'page', 'answer'],
             description: 'Optional routing hint for callers that already know the intent.'
           },
+          sessionContext: {
+            $ref: '#/components/schemas/SessionContext'
+          },
           pageStructure: {
             $ref: '#/components/schemas/PageStructure'
           }
@@ -302,17 +324,21 @@ const baseSpec = {
       AssistantResponse: {
         type: 'object',
         additionalProperties: false,
-        required: ['mode', 'speech', 'summary', 'answer', 'suggestions', 'plan'],
+        required: ['mode', 'speech', 'summary', 'answer', 'suggestions', 'plan', 'action'],
         properties: {
           mode: {
             type: 'string',
-            enum: ['answer', 'page']
+            enum: ['answer', 'page', 'action']
           },
           speech: { type: 'string' },
           summary: { type: 'string' },
           answer: { type: 'string' },
           suggestions: { type: 'array', items: { type: 'string' } },
-          plan: { $ref: '#/components/schemas/Plan' }
+          plan: { $ref: '#/components/schemas/Plan' },
+          action: {
+            nullable: true,
+            allOf: [{ $ref: '#/components/schemas/AssistantAction' }]
+          }
         }
       },
       TranscribeRequest: {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,6 +3,8 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import OpenAI, { toFile } from 'openai';
 import swaggerUi from 'swagger-ui-express';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getOpenApiSpec } from './openapi.js';
 
 dotenv.config();
@@ -288,13 +290,28 @@ function sanitizePlan(rawPlan) {
   return { steps };
 }
 
+function sanitizeAssistantAction(rawAction) {
+  if (!rawAction || typeof rawAction !== 'object' || Array.isArray(rawAction)) return null;
+  const type = typeof rawAction.type === 'string' ? rawAction.type.trim().toLowerCase() : '';
+  if (type !== 'open_site') return null;
+
+  const query = typeof rawAction.query === 'string' ? rawAction.query.trim() : '';
+  if (!query) return null;
+
+  return {
+    type: 'open_site',
+    query,
+    newTab: rawAction.newTab !== false
+  };
+}
+
 function getOpenAiClient() {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) return null;
   return new OpenAI({ apiKey });
 }
 
-async function callOpenAiSummarize(command, pageStructure, settings = DEFAULT_SETTINGS, outputLanguage = 'en') {
+async function callOpenAiSummarize(command, pageStructure, sessionContext, settings = DEFAULT_SETTINGS, outputLanguage = 'en') {
   if (settings.aiEnabled === false) {
     return null;
   }
@@ -306,9 +323,10 @@ async function callOpenAiSummarize(command, pageStructure, settings = DEFAULT_SE
 
   const systemPrompt = [
     'You are an accessibility-oriented navigator assistant for a browser extension called Navable.',
-    'You receive a structured snapshot of a web page as JSON (pageStructure) and an optional user command string.',
+    'You receive a structured snapshot of a web page as JSON (pageStructure), an optional sessionContext object, and an optional user command string.',
     'pageStructure.excerpt may contain up to ~1200 characters of visible page text; prefer it for detail.',
     'pageStructure includes counts, headings, links, buttons, landmarks, activeLabel (focused element), lang, and URL.',
+    'sessionContext may include the last purpose, last entity, last assistant reply, and a sanitized lastPage summary from the same tab.',
     `You must answer in outputLanguage "${normalizeOutputLanguage(outputLanguage)}" unless the user command explicitly requests another output language.`,
     'Your job for a blind user:',
     '- Give a concise orientation: 2–4 short sentences on what the page is, key sections/headings/controls, and any focused element worth noting.',
@@ -320,6 +338,7 @@ async function callOpenAiSummarize(command, pageStructure, settings = DEFAULT_SE
     '',
     'Important rules:',
     '- Only use the information provided in pageStructure and command; do not hallucinate hidden content.',
+    '- Use sessionContext only as a short continuity hint. If it conflicts with the current pageStructure, prefer pageStructure.',
     '- Assume the extension can only perform these actions: scroll, read_title, read_selection, read_focused, read_heading, focus_element, click_element, describe_page, wait_for_user_input, move_heading.',
     '- If you propose a plan, use ONLY those actions in plan.steps.',
     '- When referencing elements (links, headings, buttons, inputs), prefer their labels from the structure.',
@@ -340,6 +359,7 @@ async function callOpenAiSummarize(command, pageStructure, settings = DEFAULT_SE
   const userContent = JSON.stringify({
     command: command || 'Summarize this page for a blind user.',
     pageStructure,
+    sessionContext: sessionContext || null,
     outputLanguage: normalizeOutputLanguage(outputLanguage)
   });
 
@@ -367,7 +387,13 @@ async function callOpenAiSummarize(command, pageStructure, settings = DEFAULT_SE
   };
 }
 
-async function callOpenAiAnswerQuestion(question, settings = DEFAULT_SETTINGS, outputLanguage = 'en') {
+async function callOpenAiAnswerQuestion(
+  question,
+  sessionContext,
+  settings = DEFAULT_SETTINGS,
+  outputLanguage = 'en',
+  resolvedQuestion = ''
+) {
   if (settings.aiEnabled === false) {
     return null;
   }
@@ -386,18 +412,31 @@ async function callOpenAiAnswerQuestion(question, settings = DEFAULT_SETTINGS, o
           'You are a concise voice-first assistant for a browser extension called Navable.',
           `Answer in outputLanguage "${normalizeOutputLanguage(outputLanguage)}" unless the user explicitly requests another language.`,
           'The user asked a general informational question.',
+          'Navable can open websites and web apps in the browser for the user.',
+          'You may receive a sessionContext object with the previous purpose, last entity, last assistant reply, and a sanitized lastPage summary from the same tab.',
+          'You may also receive a resolvedQuestion string. If resolvedQuestion is non-empty, treat it as the fully disambiguated version of the current request.',
           'The spoken question may be colloquial Arabic, dialectal Arabic, informal English, or Arabic-English code switching.',
+          'Use sessionContext only when it clearly helps resolve a short follow-up such as "tell me more" or "what about that".',
+          'If resolvedQuestion or sessionContext already identifies the topic, answer directly and do not ask the user to specify the topic again.',
+          'If sessionContext conflicts with the current question, prefer the current question.',
+          'If the user is asking Navable to open, navigate to, visit, launch, bring up, or take them to a website, web app, or named online service, do not refuse or say that you cannot do it.',
+          'For those browser-navigation requests, return an action object with type "open_site" and a short query such as "facebook", "gmail", or a URL. Keep answer empty or use a very short acknowledgment.',
+          'If the user says "app" but the destination is also available in a browser, treat it as an "open_site" request for the browser version.',
+          'If the user is asking for information about the service instead of asking to navigate there, answer normally and return action null.',
+          'Only return an action when the navigation intent is clear.',
           'Reply with 1 to 3 short sentences that are useful when read aloud.',
           'Do not use markdown, lists, headings, or emojis.',
           'If the question is ambiguous, ask one short clarifying question instead of guessing.',
           'If you do not know, say so briefly.',
-          'Return exactly one JSON object: { "answer": string }.'
+          'Return exactly one JSON object: { "answer": string, "action": null | { "type": "open_site", "query": string, "newTab": boolean } }.'
         ].join('\n')
       },
       {
         role: 'user',
         content: JSON.stringify({
           question: String(question || '').trim(),
+          resolvedQuestion: String(resolvedQuestion || '').trim(),
+          sessionContext: sessionContext || null,
           outputLanguage: normalizeOutputLanguage(outputLanguage)
         })
       }
@@ -413,7 +452,8 @@ async function callOpenAiAnswerQuestion(question, settings = DEFAULT_SETTINGS, o
   }
 
   return {
-    answer: typeof parsed.answer === 'string' ? parsed.answer.trim() : ''
+    answer: typeof parsed.answer === 'string' ? parsed.answer.trim() : '',
+    action: sanitizeAssistantAction(parsed.action)
   };
 }
 
@@ -446,12 +486,111 @@ function isPageContextIntentText(text) {
   if (!t) return false;
   if (isSummaryIntentText(t)) return true;
   return (
-    /\b(this page|that page|page|here|this site|website|site|heading|section|link|button|field|input|title|selection|focused)\b/.test(t) ||
-    /\b(scroll|read|focus|click|press|activate|open|move|next|previous|prev|help me here|where am i|what can i do here)\b/.test(t) ||
-    /\b(cette page|page|ici|site|site web|titre|section|lien|bouton|champ|selection|focus)\b/.test(t) ||
-    /\b(fais defiler|lis|ouvre|clique|active|va|suivant|precedent|précédent|ou suis-je|où suis-je|que puis-je faire ici)\b/.test(t) ||
-    /(هذه الصفحة|الصفحة|هنا|الموقع|العنوان|القسم|الرابط|الزر|الحقل|التحديد|العنصر المحدد)/.test(t) ||
-    /(مرر|اقر[أا]|افتح|اضغط|فعّل|فعل|انتقل|التالي|السابق|أين أنا|اين انا|ماذا يمكنني أن أفعل هنا|ماذا يمكنني ان افعل هنا|شو هاي الصفحة|ايش هاي الصفحة|شو موجود هون|وين انا|على شو انا)/.test(t)
+    /\b(where am i|help me here|help on this page|help on this site|what can i do here|what can i do on this page|what can i do on this site|what is important here|what's important here|what is important on this page|what's important on this page|tell me about this page|tell me about the page|guide me here|what am i looking at|what is on this screen|what's on this screen|what is here|what's here)\b/.test(t) ||
+    /\b(o[uù] suis[- ]?je|aide[- ]?moi ici|que puis[- ]je faire ici|que puis[- ]je faire sur cette page|qu[' ]?est[- ]ce qui est important ici|qu[' ]?est[- ]ce qui est important sur cette page|parle[- ]?moi de cette page|guide[- ]?moi ici|qu[' ]?y a[- ]t[- ]il ici)\b/.test(t) ||
+    /(أين أنا|اين انا|ساعدني هنا|ساعدني هون|ماذا يمكنني أن أفعل هنا|ماذا يمكنني ان افعل هنا|شو المهم هون|ايش المهم هون|شو المهم هنا|ايش المهم هنا|احكيلي عن (?:هاي|هذه) الصفحة|احكيلي عن ه(?:اي|ذا) الموقع|دلني هون|دلني هنا|وجهني هون|وجهني هنا|شو في هون|ايش في هون|شو الموجود هون|ايش الموجود هون)/.test(t)
+  );
+}
+
+function isFollowUpIntentText(text) {
+  const t = String(text || '').trim().toLowerCase();
+  if (!t) return false;
+  return (
+    /^(tell me more|more detail|more details|go on|continue|keep going|expand that|what about that|what about it|and then)\b/.test(t) ||
+    /^(dis[- ]?m[' ]?en plus|plus de d[ée]tails|continue|vas[- ]?y|et ensuite)\b/.test(t) ||
+    /^(احكيلي اكثر|احكيلي المزيد|زيدني|كم[ّ]?ل|كمل|ماذا عن ذلك|شو كمان|ايش كمان)\b/.test(t)
+  );
+}
+
+function trimSessionText(text, maxLen = 240) {
+  const raw = String(text || '').replace(/\s+/g, ' ').trim();
+  if (!raw) return '';
+  return raw.length > maxLen ? `${raw.slice(0, Math.max(0, maxLen - 3)).trim()}...` : raw;
+}
+
+function rewriteTopicPronouns(text, topic) {
+  const raw = trimSessionText(text, 240);
+  const subject = trimSessionText(topic, 120);
+  if (!raw || !subject) return raw;
+  return raw
+    .replace(/\bits\b/gi, `${subject}'s`)
+    .replace(/\btheir\b/gi, `${subject}'s`)
+    .replace(/\bit\b/gi, subject)
+    .replace(/\bthis\b/gi, subject)
+    .replace(/\bthat\b/gi, subject)
+    .replace(/\bthey\b/gi, subject)
+    .replace(/\bthem\b/gi, subject)
+    .replace(/\bhe\b/gi, subject)
+    .replace(/\bhim\b/gi, subject)
+    .replace(/\bshe\b/gi, subject)
+    .replace(/\bher\b/gi, subject);
+}
+
+function resolveAnswerQuestionWithSessionContext(question, sessionContext = null) {
+  const rawQuestion = trimSessionText(question, 240);
+  if (!rawQuestion) {
+    return { question: '', resolvedQuestion: '', resolvedFromSession: false, topic: '' };
+  }
+
+  const lastEntity = trimSessionText(sessionContext && sessionContext.lastEntity, 120);
+  const lastUserUtterance = trimSessionText(sessionContext && sessionContext.lastUserUtterance, 180);
+  const lastAnswer = trimSessionText(sessionContext && sessionContext.lastAnswer, 220);
+  const isFollowUp = isFollowUpIntentText(rawQuestion);
+
+  if (isFollowUp) {
+    if (lastEntity) {
+      return {
+        question: rawQuestion,
+        resolvedQuestion: `Tell me more about ${lastEntity}.`,
+        resolvedFromSession: true,
+        topic: lastEntity
+      };
+    }
+    if (lastUserUtterance && !isFollowUpIntentText(lastUserUtterance)) {
+      return {
+        question: rawQuestion,
+        resolvedQuestion: `Tell me more about: ${lastUserUtterance}`,
+        resolvedFromSession: true,
+        topic: lastUserUtterance
+      };
+    }
+    if (lastAnswer) {
+      return {
+        question: rawQuestion,
+        resolvedQuestion: `Tell me more about this previous answer: ${lastAnswer}`,
+        resolvedFromSession: true,
+        topic: lastAnswer
+      };
+    }
+  }
+
+  if (lastEntity) {
+    const rewritten = rewriteTopicPronouns(rawQuestion, lastEntity);
+    if (rewritten && rewritten !== rawQuestion) {
+      return {
+        question: rawQuestion,
+        resolvedQuestion: rewritten,
+        resolvedFromSession: true,
+        topic: lastEntity
+      };
+    }
+  }
+
+  return {
+    question: rawQuestion,
+    resolvedQuestion: rawQuestion,
+    resolvedFromSession: false,
+    topic: lastEntity
+  };
+}
+
+function isClarifyingAnswerText(answer) {
+  const t = String(answer || '').trim().toLowerCase();
+  if (!t) return false;
+  return (
+    /\b(specify|clarify|which topic|what topic|which subject|what subject|more context|what would you like|which one)\b/.test(t) ||
+    /(pr[ée]ciser|quel sujet|quel thème|de quel sujet|sur quel sujet)/.test(t) ||
+    /(حدد|حدّد|أي موضوع|اي موضوع|عن ماذا|عن اي موضوع|أي شيء تقصد|اي شيء تقصد)/.test(t)
   );
 }
 
@@ -480,21 +619,22 @@ function buildAssistantSpeech(primaryText, suggestions = []) {
   return parts.join(' ').trim();
 }
 
-async function runAssistant(input, pageStructure, settings = DEFAULT_SETTINGS, outputLanguage = 'en', purpose = 'auto') {
+async function runAssistant(input, pageStructure, settings = DEFAULT_SETTINGS, outputLanguage = 'en', purpose = 'auto', sessionContext = null) {
   const resolvedOutputLanguage = normalizeOutputLanguage(outputLanguage);
   const outputCatalog = await getOutputCatalog(resolvedOutputLanguage, settings);
   const text = String(input || '').trim();
   const resolvedPurpose = typeof purpose === 'string' ? String(purpose).trim().toLowerCase() : 'auto';
-  const wantsSummary = resolvedPurpose === 'summary' || isSummaryIntentText(text);
-  const wantsPageAssistant =
-    !!pageStructure &&
-    (
-      resolvedPurpose === 'summary' ||
-      resolvedPurpose === 'page' ||
-      (!isGeneralKnowledgeQuestionText(text) || wantsSummary)
-    );
+  const priorPurpose = sessionContext && sessionContext.lastPurpose ? String(sessionContext.lastPurpose).trim().toLowerCase() : '';
+  const followUpToPage = resolvedPurpose === 'auto' && isFollowUpIntentText(text) && (priorPurpose === 'page' || priorPurpose === 'summary');
+  const wantsSummary = resolvedPurpose === 'summary' || (resolvedPurpose !== 'answer' && isSummaryIntentText(text));
+  const wantsPageIntent =
+    resolvedPurpose === 'summary' ||
+    resolvedPurpose === 'page' ||
+    followUpToPage ||
+    (resolvedPurpose === 'auto' && isPageContextIntentText(text));
+  const wantsPageAssistant = !!pageStructure && wantsPageIntent;
 
-  if (wantsSummary && !pageStructure) {
+  if (wantsPageIntent && !pageStructure) {
     const summary = outputMessage('no_page_data', resolvedOutputLanguage, {}, outputCatalog);
     return {
       mode: 'page',
@@ -509,7 +649,7 @@ async function runAssistant(input, pageStructure, settings = DEFAULT_SETTINGS, o
   if (wantsPageAssistant) {
     let result = null;
     try {
-      result = await callOpenAiSummarize(text, pageStructure, settings, resolvedOutputLanguage);
+      result = await callOpenAiSummarize(text, pageStructure, sessionContext, settings, resolvedOutputLanguage);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('[Navable backend] OpenAI page assistant error:', err);
@@ -545,11 +685,51 @@ async function runAssistant(input, pageStructure, settings = DEFAULT_SETTINGS, o
   }
 
   let answerResult = null;
+  const resolvedAnswer = resolveAnswerQuestionWithSessionContext(text, sessionContext);
   try {
-    answerResult = await callOpenAiAnswerQuestion(text, settings, resolvedOutputLanguage);
+    answerResult = await callOpenAiAnswerQuestion(
+      text,
+      sessionContext,
+      settings,
+      resolvedOutputLanguage,
+      resolvedAnswer.resolvedQuestion !== resolvedAnswer.question ? resolvedAnswer.resolvedQuestion : ''
+    );
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error('[Navable backend] OpenAI answer error:', err);
+  }
+
+  if (
+    resolvedAnswer.resolvedFromSession &&
+    answerResult &&
+    answerResult.answer &&
+    isClarifyingAnswerText(answerResult.answer)
+  ) {
+    try {
+      answerResult = await callOpenAiAnswerQuestion(
+        resolvedAnswer.resolvedQuestion,
+        sessionContext,
+        settings,
+        resolvedOutputLanguage,
+        resolvedAnswer.resolvedQuestion
+      );
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[Navable backend] OpenAI follow-up retry error:', err);
+    }
+  }
+
+  const action = sanitizeAssistantAction(answerResult && answerResult.action);
+  if (action) {
+    return {
+      mode: 'action',
+      speech: answerResult && answerResult.answer ? answerResult.answer : '',
+      summary: '',
+      answer: '',
+      suggestions: [],
+      plan: { steps: [] },
+      action
+    };
   }
 
   if (!answerResult || !answerResult.answer) {
@@ -721,12 +901,12 @@ app.post('/api/translate-messages', async (req, res) => {
 
 app.post('/api/assistant', async (req, res) => {
   try {
-    const { input, pageStructure, outputLanguage, purpose } = req.body || {};
+    const { input, pageStructure, outputLanguage, purpose, sessionContext } = req.body || {};
     if (!input || typeof input !== 'string' || !input.trim()) {
       return res.status(400).json({ error: 'Missing input' });
     }
 
-    const result = await runAssistant(input, pageStructure || null, runtimeSettings, outputLanguage, purpose || 'auto');
+    const result = await runAssistant(input, pageStructure || null, runtimeSettings, outputLanguage, purpose || 'auto', sessionContext || null);
     if (result && result.ok === false) {
       return res.status(result.status || 503).json({ error: result.error || 'Assistant unavailable' });
     }
@@ -737,7 +917,8 @@ app.post('/api/assistant', async (req, res) => {
       summary: result.summary || '',
       answer: result.answer || '',
       suggestions: Array.isArray(result.suggestions) ? result.suggestions : [],
-      plan: result.plan && Array.isArray(result.plan.steps) ? result.plan : { steps: [] }
+      plan: result.plan && Array.isArray(result.plan.steps) ? result.plan : { steps: [] },
+      action: sanitizeAssistantAction(result.action)
     });
   } catch (err) {
     // eslint-disable-next-line no-console
@@ -746,7 +927,18 @@ app.post('/api/assistant', async (req, res) => {
   }
 });
 
-app.listen(port, () => {
-  // eslint-disable-next-line no-console
-  console.log(`[Navable backend] Listening on http://localhost:${port}`);
-});
+const isDirectRun = process.argv[1] ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+
+if (isDirectRun) {
+  app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`[Navable backend] Listening on http://localhost:${port}`);
+  });
+}
+
+export {
+  app,
+  isClarifyingAnswerText,
+  resolveAnswerQuestionWithSessionContext,
+  runAssistant
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,6 +5,11 @@ import OpenAI, { toFile } from 'openai';
 import swaggerUi from 'swagger-ui-express';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  isClarifyingAnswerText,
+  isFollowUpIntentText,
+  resolveAnswerQuestionWithSessionContext
+} from './assistant-session.js';
 import { getOpenApiSpec } from './openapi.js';
 
 dotenv.config();
@@ -489,108 +494,6 @@ function isPageContextIntentText(text) {
     /\b(where am i|help me here|help on this page|help on this site|what can i do here|what can i do on this page|what can i do on this site|what is important here|what's important here|what is important on this page|what's important on this page|tell me about this page|tell me about the page|guide me here|what am i looking at|what is on this screen|what's on this screen|what is here|what's here)\b/.test(t) ||
     /\b(o[uù] suis[- ]?je|aide[- ]?moi ici|que puis[- ]je faire ici|que puis[- ]je faire sur cette page|qu[' ]?est[- ]ce qui est important ici|qu[' ]?est[- ]ce qui est important sur cette page|parle[- ]?moi de cette page|guide[- ]?moi ici|qu[' ]?y a[- ]t[- ]il ici)\b/.test(t) ||
     /(أين أنا|اين انا|ساعدني هنا|ساعدني هون|ماذا يمكنني أن أفعل هنا|ماذا يمكنني ان افعل هنا|شو المهم هون|ايش المهم هون|شو المهم هنا|ايش المهم هنا|احكيلي عن (?:هاي|هذه) الصفحة|احكيلي عن ه(?:اي|ذا) الموقع|دلني هون|دلني هنا|وجهني هون|وجهني هنا|شو في هون|ايش في هون|شو الموجود هون|ايش الموجود هون)/.test(t)
-  );
-}
-
-function isFollowUpIntentText(text) {
-  const t = String(text || '').trim().toLowerCase();
-  if (!t) return false;
-  return (
-    /^(tell me more|more detail|more details|go on|continue|keep going|expand that|what about that|what about it|and then)\b/.test(t) ||
-    /^(dis[- ]?m[' ]?en plus|plus de d[ée]tails|continue|vas[- ]?y|et ensuite)\b/.test(t) ||
-    /^(احكيلي اكثر|احكيلي المزيد|زيدني|كم[ّ]?ل|كمل|ماذا عن ذلك|شو كمان|ايش كمان)\b/.test(t)
-  );
-}
-
-function trimSessionText(text, maxLen = 240) {
-  const raw = String(text || '').replace(/\s+/g, ' ').trim();
-  if (!raw) return '';
-  return raw.length > maxLen ? `${raw.slice(0, Math.max(0, maxLen - 3)).trim()}...` : raw;
-}
-
-function rewriteTopicPronouns(text, topic) {
-  const raw = trimSessionText(text, 240);
-  const subject = trimSessionText(topic, 120);
-  if (!raw || !subject) return raw;
-  return raw
-    .replace(/\bits\b/gi, `${subject}'s`)
-    .replace(/\btheir\b/gi, `${subject}'s`)
-    .replace(/\bit\b/gi, subject)
-    .replace(/\bthis\b/gi, subject)
-    .replace(/\bthat\b/gi, subject)
-    .replace(/\bthey\b/gi, subject)
-    .replace(/\bthem\b/gi, subject)
-    .replace(/\bhe\b/gi, subject)
-    .replace(/\bhim\b/gi, subject)
-    .replace(/\bshe\b/gi, subject)
-    .replace(/\bher\b/gi, subject);
-}
-
-function resolveAnswerQuestionWithSessionContext(question, sessionContext = null) {
-  const rawQuestion = trimSessionText(question, 240);
-  if (!rawQuestion) {
-    return { question: '', resolvedQuestion: '', resolvedFromSession: false, topic: '' };
-  }
-
-  const lastEntity = trimSessionText(sessionContext && sessionContext.lastEntity, 120);
-  const lastUserUtterance = trimSessionText(sessionContext && sessionContext.lastUserUtterance, 180);
-  const lastAnswer = trimSessionText(sessionContext && sessionContext.lastAnswer, 220);
-  const isFollowUp = isFollowUpIntentText(rawQuestion);
-
-  if (isFollowUp) {
-    if (lastEntity) {
-      return {
-        question: rawQuestion,
-        resolvedQuestion: `Tell me more about ${lastEntity}.`,
-        resolvedFromSession: true,
-        topic: lastEntity
-      };
-    }
-    if (lastUserUtterance && !isFollowUpIntentText(lastUserUtterance)) {
-      return {
-        question: rawQuestion,
-        resolvedQuestion: `Tell me more about: ${lastUserUtterance}`,
-        resolvedFromSession: true,
-        topic: lastUserUtterance
-      };
-    }
-    if (lastAnswer) {
-      return {
-        question: rawQuestion,
-        resolvedQuestion: `Tell me more about this previous answer: ${lastAnswer}`,
-        resolvedFromSession: true,
-        topic: lastAnswer
-      };
-    }
-  }
-
-  if (lastEntity) {
-    const rewritten = rewriteTopicPronouns(rawQuestion, lastEntity);
-    if (rewritten && rewritten !== rawQuestion) {
-      return {
-        question: rawQuestion,
-        resolvedQuestion: rewritten,
-        resolvedFromSession: true,
-        topic: lastEntity
-      };
-    }
-  }
-
-  return {
-    question: rawQuestion,
-    resolvedQuestion: rawQuestion,
-    resolvedFromSession: false,
-    topic: lastEntity
-  };
-}
-
-function isClarifyingAnswerText(answer) {
-  const t = String(answer || '').trim().toLowerCase();
-  if (!t) return false;
-  return (
-    /\b(specify|clarify|which topic|what topic|which subject|what subject|more context|what would you like|which one)\b/.test(t) ||
-    /(pr[ée]ciser|quel sujet|quel thème|de quel sujet|sur quel sujet)/.test(t) ||
-    /(حدد|حدّد|أي موضوع|اي موضوع|عن ماذا|عن اي موضوع|أي شيء تقصد|اي شيء تقصد)/.test(t)
   );
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,55 @@
+function createMemoryStorageArea() {
+  const data = {};
+  return {
+    _data: data,
+    get(query, cb) {
+      if (query === null || typeof query === 'undefined') {
+        cb({ ...data });
+        return;
+      }
+      if (Array.isArray(query)) {
+        cb(query.reduce((acc, key) => {
+          acc[key] = Object.prototype.hasOwnProperty.call(data, key) ? data[key] : undefined;
+          return acc;
+        }, {}));
+        return;
+      }
+      if (typeof query === 'string') {
+        cb({ [query]: Object.prototype.hasOwnProperty.call(data, query) ? data[query] : undefined });
+        return;
+      }
+      const defaults = query && typeof query === 'object' ? query : {};
+      cb(Object.keys(defaults).reduce((acc, key) => {
+        acc[key] = Object.prototype.hasOwnProperty.call(data, key) ? data[key] : defaults[key];
+        return acc;
+      }, {}));
+    },
+    set(items, cb) {
+      Object.keys(items || {}).forEach((key) => {
+        data[key] = items[key];
+      });
+      if (typeof cb === 'function') cb();
+    },
+    remove(keys, cb) {
+      const keyList = Array.isArray(keys) ? keys : [keys];
+      keyList.forEach((key) => {
+        delete data[key];
+      });
+      if (typeof cb === 'function') cb();
+    },
+    clear(cb) {
+      Object.keys(data).forEach((key) => {
+        delete data[key];
+      });
+      if (typeof cb === 'function') cb();
+    }
+  };
+}
+
 // Test fallback: if chrome is missing (non-extension env), create a minimal shim so tests can run.
 if (typeof window !== 'undefined' && typeof chrome === 'undefined') {
+  const syncStorage = createMemoryStorageArea();
+  const sessionStorage = createMemoryStorageArea();
   window.chrome = {
     commands: {
       _listeners: [],
@@ -18,6 +68,7 @@ if (typeof window !== 'undefined' && typeof chrome === 'undefined') {
       _created: [],
       onCreated: { addListener() {} },
       onUpdated: { addListener() {} },
+      onRemoved: { addListener() {} },
       query() { return Promise.resolve([{ id: 1 }]); },
       create(createProperties) {
         const url = createProperties && createProperties.url ? String(createProperties.url) : 'about:blank';
@@ -89,9 +140,8 @@ if (typeof window !== 'undefined' && typeof chrome === 'undefined') {
       }
     },
     storage: {
-      sync: {
-        get(defaults, cb) { cb(defaults); }
-      },
+      sync: syncStorage,
+      session: sessionStorage,
       onChanged: { addListener() {} }
     }
   };
@@ -547,6 +597,395 @@ function isSummaryCommandText(text) {
   );
 }
 
+function isPageAssistantRequestText(text) {
+  const t = String(text || '').trim().toLowerCase();
+  if (!t) return false;
+  if (isSummaryCommandText(t)) return true;
+  return (
+    /\b(where am i|help me here|help on this page|help on this site|what can i do here|what can i do on this page|what can i do on this site|what is important here|what's important here|what is important on this page|what's important on this page|tell me about this page|tell me about the page|guide me here|what am i looking at|what is on this screen|what's on this screen|what is here|what's here)\b/.test(t) ||
+    /\b(o[uù] suis[- ]?je|aide[- ]?moi ici|que puis[- ]je faire ici|que puis[- ]je faire sur cette page|qu[' ]?est[- ]ce qui est important ici|qu[' ]?est[- ]ce qui est important sur cette page|parle[- ]?moi de cette page|guide[- ]?moi ici|qu[' ]?y a[- ]t[- ]il ici)\b/.test(t) ||
+    /(أين أنا|اين انا|ساعدني هنا|ساعدني هون|ماذا يمكنني أن أفعل هنا|ماذا يمكنني ان افعل هنا|شو المهم هون|ايش المهم هون|شو المهم هنا|ايش المهم هنا|احكيلي عن (?:هاي|هذه) الصفحة|احكيلي عن ه(?:اي|ذا) الموقع|دلني هون|دلني هنا|وجهني هون|وجهني هنا|شو في هون|ايش في هون|شو الموجود هون|ايش الموجود هون)/.test(t)
+  );
+}
+
+function isSessionFollowUpText(text) {
+  const t = String(text || '').trim().toLowerCase();
+  if (!t) return false;
+  return (
+    /^(tell me more|more detail|more details|go on|continue|keep going|expand that|what about that|what about it|and then)\b/.test(t) ||
+    /^(dis[- ]?m[' ]?en plus|plus de d[ée]tails|continue|vas[- ]?y|et ensuite)\b/.test(t) ||
+    /^(احكيلي اكثر|احكيلي المزيد|زيدني|كم[ّ]?ل|كمل|ماذا عن ذلك|شو كمان|ايش كمان)\b/.test(t)
+  );
+}
+
+function trimSessionText(text, maxLen = 240) {
+  const raw = String(text || '').replace(/\s+/g, ' ').trim();
+  if (!raw) return '';
+  return raw.length > maxLen ? `${raw.slice(0, Math.max(0, maxLen - 3)).trim()}...` : raw;
+}
+
+function hostForUrl(url) {
+  try {
+    return new URL(String(url || '')).hostname.toLowerCase();
+  } catch (_err) {
+    return '';
+  }
+}
+
+function extractReferencedEntity(text) {
+  const raw = trimSessionText(text, 160);
+  if (!raw || isSessionFollowUpText(raw)) return '';
+  const cleaned = trimSessionText(
+    raw
+      .replace(/^[“"'`]+|[”"'`]+$/g, '')
+      .replace(/^(who|what|when|where|why|how)\s+(is|are|was|were)\s+/i, '')
+      .replace(/^(explain|define|compare|tell me about|more about|what about)\s+/i, '')
+      .replace(/^(qui|que|qu[' ]?est[- ]?ce que|qu[' ]?est-ce que|explique|definis|définis|compare|parle[- ]?moi de|dis[- ]?moi)\s+/i, '')
+      .replace(/^(من|ما هو|ما هي|ما|اشرح|عر[ّ]ف|عرف|احكيلي عن|قل لي عن|خبرني عن|شو هو|ايش هو)\s+/i, '')
+      .replace(/^(the|a|an|le|la|les|un|une|ال)\s+/i, '')
+      .replace(/[?!.]+$/g, ''),
+    80
+  );
+  return cleaned;
+}
+
+function isSensitivePageStructure(structure) {
+  const privacy = structure && structure.privacy ? structure.privacy : {};
+  return !!(privacy && (privacy.sensitivePage || Number(privacy.sensitiveInputCount || 0) > 0));
+}
+
+function sanitizePageMemory(structure, summaryText) {
+  if (!structure) return null;
+  const privacy = structure && structure.privacy ? structure.privacy : {};
+  const sensitiveInputCount = Math.max(0, Number(privacy.sensitiveInputCount || 0));
+  const sensitivePage = isSensitivePageStructure(structure);
+  return {
+    url: trimSessionText(structure.url, 280),
+    host: hostForUrl(structure.url),
+    title: trimSessionText(structure.title, 120),
+    topHeading: trimSessionText(structure && structure.headings && structure.headings[0] ? structure.headings[0].label : '', 120),
+    activeLabel: sensitivePage ? '' : trimSessionText(structure.activeLabel, 120),
+    summary: sensitivePage ? '' : trimSessionText(summaryText, 260),
+    sensitivePage,
+    sensitiveInputCount
+  };
+}
+
+const SESSION_TTL_MS = 15 * 60 * 1000;
+const DOMAIN_HABIT_TTL_MS = 24 * 60 * 60 * 1000;
+const GLOBAL_SESSION_KEY = '__global__';
+const SESSION_STORAGE_PREFIX = 'navable.session.';
+const DOMAIN_HABIT_STORAGE_PREFIX = 'navable.domainHabit.';
+const assistantSessionFallback = new Map();
+const domainHabitFallback = new Map();
+
+function sessionKeyForSource(sourceTabId) {
+  return sourceTabId || GLOBAL_SESSION_KEY;
+}
+
+function assistantSessionStorageKey(sourceTabId) {
+  return `${SESSION_STORAGE_PREFIX}${sessionKeyForSource(sourceTabId)}`;
+}
+
+function domainHabitStorageKey(host) {
+  return `${DOMAIN_HABIT_STORAGE_PREFIX}${String(host || '').trim().toLowerCase()}`;
+}
+
+function sessionStorageArea() {
+  try {
+    return chrome && chrome.storage && chrome.storage.session && typeof chrome.storage.session.get === 'function'
+      ? chrome.storage.session
+      : null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+function storageAreaGet(area, query) {
+  return new Promise((resolve) => {
+    if (!area || typeof area.get !== 'function') {
+      resolve({});
+      return;
+    }
+    try {
+      area.get(query, (res) => {
+        resolve(res || {});
+      });
+    } catch (_err) {
+      resolve({});
+    }
+  });
+}
+
+function storageAreaSet(area, items) {
+  return new Promise((resolve) => {
+    if (!area || typeof area.set !== 'function') {
+      resolve();
+      return;
+    }
+    try {
+      area.set(items, () => resolve());
+    } catch (_err) {
+      resolve();
+    }
+  });
+}
+
+function storageAreaRemove(area, keys) {
+  return new Promise((resolve) => {
+    if (!area || typeof area.remove !== 'function') {
+      resolve();
+      return;
+    }
+    try {
+      area.remove(keys, () => resolve());
+    } catch (_err) {
+      resolve();
+    }
+  });
+}
+
+async function readScopedMemory(storageKey, fallbackMap, ttlMs) {
+  const now = Date.now();
+  const area = sessionStorageArea();
+  if (area) {
+    const result = await storageAreaGet(area, { [storageKey]: null });
+    const value = result && Object.prototype.hasOwnProperty.call(result, storageKey) ? result[storageKey] : null;
+    if (value && value.updatedAt && now - value.updatedAt <= ttlMs) {
+      return { ...value };
+    }
+    if (value) {
+      await storageAreaRemove(area, [storageKey]);
+    }
+    return null;
+  }
+  const fallback = fallbackMap.get(storageKey);
+  if (fallback && fallback.updatedAt && now - fallback.updatedAt <= ttlMs) {
+    return { ...fallback };
+  }
+  fallbackMap.delete(storageKey);
+  return null;
+}
+
+async function writeScopedMemory(storageKey, value, fallbackMap) {
+  const normalized = {
+    ...(value || {}),
+    updatedAt: Date.now()
+  };
+  const area = sessionStorageArea();
+  if (area) {
+    await storageAreaSet(area, { [storageKey]: normalized });
+    return normalized;
+  }
+  fallbackMap.set(storageKey, normalized);
+  return normalized;
+}
+
+async function removeScopedMemory(storageKey, fallbackMap) {
+  fallbackMap.delete(storageKey);
+  const area = sessionStorageArea();
+  if (area) {
+    await storageAreaRemove(area, [storageKey]);
+  }
+}
+
+async function getAssistantSession(sourceTabId) {
+  return await readScopedMemory(
+    assistantSessionStorageKey(sourceTabId),
+    assistantSessionFallback,
+    SESSION_TTL_MS
+  );
+}
+
+async function setAssistantSession(sourceTabId, session) {
+  return await writeScopedMemory(
+    assistantSessionStorageKey(sourceTabId),
+    session,
+    assistantSessionFallback
+  );
+}
+
+async function clearAssistantSession(sourceTabId) {
+  await removeScopedMemory(
+    assistantSessionStorageKey(sourceTabId),
+    assistantSessionFallback
+  );
+}
+
+async function ensureDomainHabit(host) {
+  const normalizedHost = String(host || '').trim().toLowerCase();
+  if (!normalizedHost) return null;
+  const existing = await readScopedMemory(
+    domainHabitStorageKey(normalizedHost),
+    domainHabitFallback,
+    DOMAIN_HABIT_TTL_MS
+  );
+  if (existing) return existing;
+  return {
+    host: normalizedHost,
+    updatedAt: 0,
+    purposeCounts: { answer: 0, page: 0, summary: 0 },
+    lastEntity: '',
+    lastPageTitle: '',
+    lastAction: ''
+  };
+}
+
+function dominantDomainPurpose(entry) {
+  if (!entry || !entry.purposeCounts) return '';
+  const counts = entry.purposeCounts;
+  const order = ['answer', 'page', 'summary'];
+  let best = '';
+  let bestCount = 0;
+  order.forEach((purpose) => {
+    const count = Number(counts[purpose] || 0);
+    if (count > bestCount) {
+      best = purpose;
+      bestCount = count;
+    }
+  });
+  return best;
+}
+
+async function recordDomainHabit(host, updates = {}) {
+  const entry = await ensureDomainHabit(host);
+  if (!entry) return;
+  entry.updatedAt = Date.now();
+  if (updates.purpose && Object.prototype.hasOwnProperty.call(entry.purposeCounts, updates.purpose)) {
+    entry.purposeCounts[updates.purpose] += 1;
+  }
+  if (updates.entity) entry.lastEntity = trimSessionText(updates.entity, 80);
+  if (updates.pageTitle) entry.lastPageTitle = trimSessionText(updates.pageTitle, 120);
+  if (updates.action) entry.lastAction = trimSessionText(updates.action, 120);
+  await writeScopedMemory(domainHabitStorageKey(entry.host), entry, domainHabitFallback);
+}
+
+async function buildDomainHabitSnapshot(host) {
+  const entry = await ensureDomainHabit(host);
+  if (!entry) return null;
+  return {
+    host: entry.host,
+    dominantPurpose: dominantDomainPurpose(entry),
+    lastEntity: trimSessionText(entry.lastEntity, 80),
+    lastPageTitle: trimSessionText(entry.lastPageTitle, 120),
+    lastAction: trimSessionText(entry.lastAction, 120)
+  };
+}
+
+function hostFromSessionRequest(options = {}, structure = null) {
+  return hostForUrl(
+    options.pageUrl ||
+    (structure && structure.url ? structure.url : '') ||
+    (options.pageStructure && options.pageStructure.url ? options.pageStructure.url : '')
+  );
+}
+
+async function buildSessionContext(sourceTabId) {
+  const session = await getAssistantSession(sourceTabId);
+  if (!session) return null;
+  const host = session.host || (session.lastPage && session.lastPage.host) || '';
+  return {
+    lastPurpose: session.lastPurpose || '',
+    lastUserUtterance: session.lastInput || '',
+    lastEntity: session.lastEntity || '',
+    lastAssistantReply: session.lastAssistantSpeech || '',
+    lastAnswer: session.lastAnswer || '',
+    lastPage: session.lastPage || null,
+    lastAction: session.lastAction || '',
+    outputLanguage: session.outputLanguage || '',
+    detectedLanguage: session.detectedLanguage || '',
+    recognitionProvider: session.recognitionProvider || '',
+    domainHabits: await buildDomainHabitSnapshot(host)
+  };
+}
+
+async function rememberAssistantTurn(sourceTabId, info = {}) {
+  const existing = await getAssistantSession(sourceTabId) || {};
+  const input = trimSessionText(info.input, 180);
+  const purpose = info.purpose || existing.lastPurpose || '';
+  const summary = trimSessionText(info.summary, 260);
+  const answer = trimSessionText(info.answer, 260);
+  const speech = trimSessionText(info.speech || info.description || answer || summary, 260);
+  const pageMemory = info.structure
+    ? sanitizePageMemory(info.structure, summary || speech)
+    : (existing.lastPage || null);
+  const host = hostForUrl((pageMemory && pageMemory.url) || info.pageUrl || existing.host || '');
+  const entity = extractReferencedEntity(info.input) || existing.lastEntity || '';
+  const action = trimSessionText(
+    info.action ||
+      (info.plan && info.plan.steps && info.plan.steps.length && info.plan.steps[0] && info.plan.steps[0].action
+        ? info.plan.steps[0].action
+        : '') ||
+      existing.lastAction,
+    120
+  );
+
+  await setAssistantSession(sourceTabId, {
+    host,
+    lastPurpose: purpose,
+    lastInput: input || existing.lastInput || '',
+    lastEntity: entity,
+    lastAssistantSpeech: speech || existing.lastAssistantSpeech || '',
+    lastAnswer: answer || existing.lastAnswer || '',
+    lastSummary: summary || existing.lastSummary || '',
+    lastAction: action,
+    outputLanguage: info.outputLanguage || existing.outputLanguage || '',
+    detectedLanguage: info.detectedLanguage || existing.detectedLanguage || '',
+    recognitionProvider: info.recognitionProvider || existing.recognitionProvider || '',
+    lastPage: pageMemory
+  });
+
+  if (host) {
+    await recordDomainHabit(host, {
+      purpose: purpose === 'summary' ? 'summary' : purpose === 'page' ? 'page' : purpose === 'answer' ? 'answer' : '',
+      entity,
+      pageTitle: pageMemory && !pageMemory.sensitivePage ? pageMemory.title : '',
+      action
+    });
+  }
+}
+
+async function rememberActionTurn(sourceTabId, info = {}) {
+  const existing = await getAssistantSession(sourceTabId) || {};
+  const pageMemory = info.structure ? sanitizePageMemory(info.structure, '') : (existing.lastPage || null);
+  const host = hostForUrl((pageMemory && pageMemory.url) || info.url || existing.host || '');
+  const action = trimSessionText(info.action, 120);
+  await setAssistantSession(sourceTabId, {
+    host,
+    lastPurpose: existing.lastPurpose || '',
+    lastInput: existing.lastInput || '',
+    lastEntity: existing.lastEntity || '',
+    lastAssistantSpeech: existing.lastAssistantSpeech || '',
+    lastAnswer: existing.lastAnswer || '',
+    lastSummary: existing.lastSummary || '',
+    lastAction: action || existing.lastAction || '',
+    outputLanguage: info.outputLanguage || existing.outputLanguage || '',
+    detectedLanguage: existing.detectedLanguage || '',
+    recognitionProvider: existing.recognitionProvider || '',
+    lastPage: pageMemory
+  });
+  if (host && action) {
+    await recordDomainHabit(host, {
+      pageTitle: pageMemory && !pageMemory.sensitivePage ? pageMemory.title : '',
+      action
+    });
+  }
+}
+
+function assistantPurposeForText(text, includePageContext, explicitPurpose, session) {
+  const rawPurpose = typeof explicitPurpose === 'string' ? String(explicitPurpose).trim().toLowerCase() : '';
+  if (rawPurpose === 'summary' || rawPurpose === 'page' || rawPurpose === 'answer') return rawPurpose;
+  if (isSummaryCommandText(text)) return 'summary';
+  if (isPageAssistantRequestText(text)) return 'page';
+  if (isSessionFollowUpText(text)) {
+    const priorPurpose = session && session.lastPurpose ? String(session.lastPurpose).trim().toLowerCase() : '';
+    if (priorPurpose === 'summary' || priorPurpose === 'page') return 'page';
+    if (priorPurpose === 'answer') return 'answer';
+  }
+  if (!includePageContext) return 'answer';
+  return 'answer';
+}
+
 function buildFriendlyOrientation(structure, outputLanguage) {
   if (!structure) return outputMessage('summary_unavailable', outputLanguage);
   const counts = structure.counts || {};
@@ -582,12 +1021,91 @@ async function loadSettings() {
   });
 }
 
+function normalizeAssistantAction(data) {
+  const raw = data && data.action && typeof data.action === 'object' ? data.action : null;
+  if (!raw || Array.isArray(raw)) return null;
+  const type = typeof raw.type === 'string' ? raw.type.trim().toLowerCase() : '';
+  if (type !== 'open_site') return null;
+  const query = typeof raw.query === 'string' ? raw.query.trim() : '';
+  if (!query) return null;
+  return {
+    type: 'open_site',
+    query,
+    newTab: raw.newTab !== false
+  };
+}
+
+function stripOpenIntentPrefixes(text) {
+  let value = String(text || '').trim().toLowerCase();
+  if (!value) return '';
+
+  const prefixes = [
+    /^(?:hey\s+navable|navable|please|pls)\b[\s,]*/,
+    /^(?:can you|could you|would you|will you)\b[\s,]*/,
+    /^(?:peux[- ]?tu|pourrais[- ]?tu|tu peux|svp|stp|s['’]?il te pla[îi]t)\b[\s,]*/,
+    /^(?:لو سمحت|من فضلك|رجاءً?|رجاء|ممكن|بتقدر|تقدر)\b[\s،]*/
+  ];
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const pattern of prefixes) {
+      const next = value.replace(pattern, '').trim();
+      if (next !== value) {
+        value = next;
+        changed = true;
+      }
+    }
+  }
+
+  return value;
+}
+
+function extractAssistantOpenSiteQuery(text) {
+  const normalized = stripOpenIntentPrefixes(text);
+  if (!normalized) return null;
+
+  const ar = normalized.match(/^(افتح(?:\s+لي)?|خذني\s+على|خذني\s+إلى|خذني\s+الى|وديني\s+على|وديني\s+إلى|وديني\s+الى|اذهب\s+إلى|اذهب\s+الى|روح\s+على|روح\s+إلى|روح\s+الى|انتقل\s+إلى|انتقل\s+الى|خليني\s+أروح\s+على|خليني\s+اروح\s+على|خلينا\s+نروح\s+على)\s+(.+)$/);
+  if (ar && ar[2]) return String(ar[2]).trim();
+
+  const fr = normalized.match(/^(ouvre|va(?:s)?\s+(?:a|à)|aller?\s+(?:a|à)|visite|lance)\s+(.+)$/);
+  if (fr && fr[2]) {
+    return String(fr[2])
+      .trim()
+      .replace(/^(le|la|les|un|une)\b/, '')
+      .trim()
+      .replace(/^(site|page|onglet|application|appli)\b/, '')
+      .trim();
+  }
+
+  const en = normalized.match(/^(open(?:\s+up)?|navigate to|go to|take me to|visit|bring up|launch|pull up)\s+(.+)$/);
+  if (!en || !en[2]) return null;
+
+  const query = String(en[2])
+    .trim()
+    .replace(/^(me|for me)\b/, '')
+    .trim()
+    .replace(/^(a|an|the)\b/, '')
+    .trim()
+    .replace(/^(new\s+)?tab\b/, '')
+    .trim()
+    .replace(/^(website|site|page|app)\b/, '')
+    .trim()
+    .replace(/\bfor me\b/g, '')
+    .trim()
+    .replace(/\bplease\b/g, '')
+    .trim();
+
+  return query || null;
+}
+
 function normalizeAssistantResult(data) {
   const summary = data && typeof data.summary === 'string' ? data.summary.trim() : '';
   const answer = data && typeof data.answer === 'string' ? data.answer.trim() : '';
   const speech = data && typeof data.speech === 'string' ? data.speech.trim() : '';
   const suggestions = Array.isArray(data && data.suggestions) ? data.suggestions : [];
   const plan = data && data.plan && Array.isArray(data.plan.steps) ? data.plan : { steps: [] };
+  const action = normalizeAssistantAction(data);
   const description = speech || [summary, suggestions.join(' ')].filter(Boolean).join(' ').trim();
   return {
     mode: data && typeof data.mode === 'string' ? data.mode : 'answer',
@@ -596,7 +1114,8 @@ function normalizeAssistantResult(data) {
     summary,
     answer,
     suggestions,
-    plan
+    plan,
+    action
   };
 }
 
@@ -606,14 +1125,59 @@ async function requestAssistant(input, requestedOutputLanguage, options = {}) {
   const outputMessagesReady = ensureOutputMessages(outputLanguage);
   const text = String(input || '').trim();
   const sourceTabId = options.sourceTabId || null;
+  const requestHost = hostFromSessionRequest(options);
+  let previousSession = await getAssistantSession(sourceTabId);
+  if (previousSession && requestHost && previousSession.host && previousSession.host !== requestHost) {
+    await clearAssistantSession(sourceTabId);
+    previousSession = null;
+  }
+  const purpose = assistantPurposeForText(text, !!options.includePageContext, options.purpose, previousSession);
+  const shouldIncludePageContext = purpose === 'summary' || purpose === 'page';
+  const sessionContext = await buildSessionContext(sourceTabId);
 
   if (!text) {
     await outputMessagesReady;
     return { ok: false, error: outputMessage('answer_unavailable', outputLanguage) };
   }
 
-  let structure = options.pageStructure || null;
-  if (!structure && options.includePageContext) {
+  const directOpenQuery = extractAssistantOpenSiteQuery(text);
+  if (directOpenQuery) {
+    const action = { type: 'open_site', query: directOpenQuery, newTab: true };
+    const openResult = await openSiteInBrowser(directOpenQuery, true, outputLanguage, {
+      sourceTabId,
+      announce: false
+    });
+    if (!openResult.ok) {
+      return { ok: false, error: openResult.error || outputMessage('open_website_failed', outputLanguage) };
+    }
+
+    await rememberAssistantTurn(sourceTabId, {
+      input: text,
+      purpose: 'answer',
+      outputLanguage,
+      speech: openResult.speech || '',
+      detectedLanguage: options.detectedLanguage || '',
+      recognitionProvider: options.recognitionProvider || '',
+      pageUrl: openResult.url || ''
+    });
+
+    return {
+      ok: true,
+      structure: null,
+      mode: 'action',
+      speech: openResult.speech || '',
+      description: openResult.speech || '',
+      summary: '',
+      answer: '',
+      suggestions: [],
+      plan: { steps: [] },
+      action,
+      url: openResult.url || ''
+    };
+  }
+
+  let structure = shouldIncludePageContext ? (options.pageStructure || null) : null;
+  if (!structure && shouldIncludePageContext) {
     try {
       const structureRes = await sendToTargetTab(sourceTabId, { type: 'navable:getStructure' });
       structure = structureRes && structureRes.structure ? structureRes.structure : null;
@@ -630,12 +1194,65 @@ async function requestAssistant(input, requestedOutputLanguage, options = {}) {
         input: text,
         outputLanguage,
         pageStructure: structure,
-        purpose: options.purpose || 'auto'
+        purpose,
+        sessionContext
       })
     });
     const data = await response.json().catch(() => ({}));
     if (response.ok) {
-      return { ok: true, structure, ...normalizeAssistantResult(data) };
+      const normalized = normalizeAssistantResult(data);
+      if (normalized.action && normalized.action.type === 'open_site') {
+        const openResult = await openSiteInBrowser(
+          normalized.action.query,
+          normalized.action.newTab,
+          outputLanguage,
+          { sourceTabId, announce: false }
+        );
+        if (!openResult.ok) {
+          return { ok: false, structure, error: openResult.error || outputMessage('open_website_failed', outputLanguage) };
+        }
+
+        const actionSpeech = openResult.speech || normalized.speech || '';
+        await rememberAssistantTurn(sourceTabId, {
+          input: text,
+          purpose: 'answer',
+          outputLanguage,
+          speech: actionSpeech,
+          detectedLanguage: options.detectedLanguage || '',
+          recognitionProvider: options.recognitionProvider || '',
+          pageUrl: openResult.url || ''
+        });
+
+        return {
+          ok: true,
+          structure,
+          mode: 'action',
+          speech: actionSpeech,
+          description: actionSpeech,
+          summary: '',
+          answer: '',
+          suggestions: [],
+          plan: { steps: [] },
+          action: normalized.action,
+          url: openResult.url || ''
+        };
+      }
+
+      await rememberAssistantTurn(sourceTabId, {
+        input: text,
+        purpose,
+        outputLanguage,
+        structure,
+        speech: normalized.speech,
+        description: normalized.description,
+        summary: normalized.summary,
+        answer: normalized.answer,
+        plan: normalized.plan,
+        detectedLanguage: options.detectedLanguage || '',
+        recognitionProvider: options.recognitionProvider || '',
+        pageUrl: options.pageUrl || (structure && structure.url ? structure.url : '')
+      });
+      return { ok: true, structure, ...normalized };
     }
     if (data && typeof data.error === 'string' && data.error.trim()) {
       return { ok: false, structure, error: data.error.trim() };
@@ -754,6 +1371,15 @@ async function runPlanner(command, requestedOutputLanguage, preferIntentFallback
         mode: 'assertive',
         lang: outputLocale(outputLanguage)
       });
+      await rememberAssistantTurn(sourceTabId, {
+        input: command,
+        purpose: 'summary',
+        outputLanguage,
+        structure,
+        speech: description,
+        summary: description,
+        pageUrl: structure && structure.url ? structure.url : ''
+      });
       return {
         ok: true,
         plan: { steps: [] },
@@ -782,6 +1408,25 @@ async function runPlanner(command, requestedOutputLanguage, preferIntentFallback
   }
   if (plan.steps && plan.steps.length) {
     await sendToTargetTab(sourceTabId, { type: 'navable:executePlan', plan: { steps: plan.steps } });
+  }
+
+  if (isSummaryRequest || plan.description) {
+    await rememberAssistantTurn(sourceTabId, {
+      input: command,
+      purpose: isSummaryRequest ? 'summary' : 'page',
+      outputLanguage,
+      structure,
+      speech: plan.description || '',
+      summary: plan.description || '',
+      plan,
+      pageUrl: structure && structure.url ? structure.url : ''
+    });
+  } else if (plan.steps && plan.steps.length) {
+    await rememberActionTurn(sourceTabId, {
+      action: plan.steps[0].action || '',
+      outputLanguage,
+      structure
+    });
   }
 
   return { ok: true, plan, structure };
@@ -1003,16 +1648,19 @@ async function openSiteInBrowser(query, newTab, requestedOutputLanguage, options
   const sourceTabId = options.sourceTabId || null;
   if (!url) return { ok: false, error: outputMessage('missing_url', outputLanguage) };
 
-  outputMessagesReady.then(() => (
-    sendToTargetTab(sourceTabId, {
-      type: 'navable:announce',
-      text: outputMessage('opening_value', outputLanguage, { value: friendlyUrlForSpeech(url) }),
-      mode: 'assertive',
-      lang: outputLocale(outputLanguage)
-    })
-  )).catch(() => {
-    // ignore announce failures (e.g., unsupported active tab)
-  });
+  const speech = outputMessage('opening_value', outputLanguage, { value: friendlyUrlForSpeech(url) });
+  if (options.announce !== false) {
+    outputMessagesReady.then(() => (
+      sendToTargetTab(sourceTabId, {
+        type: 'navable:announce',
+        text: outputMessage('opening_value', outputLanguage, { value: friendlyUrlForSpeech(url) }),
+        mode: 'assertive',
+        lang: outputLocale(outputLanguage)
+      })
+    )).catch(() => {
+      // ignore announce failures (e.g., unsupported active tab)
+    });
+  }
 
   try {
     if (newTab === false) {
@@ -1029,10 +1677,26 @@ async function openSiteInBrowser(query, newTab, requestedOutputLanguage, options
     } else {
       await chrome.tabs.create({ url });
     }
-    return { ok: true, url };
+    await rememberActionTurn(sourceTabId, {
+      action: 'open_site',
+      outputLanguage,
+      url
+    });
+    return { ok: true, url, speech };
   } catch (err) {
     console.warn('[Navable] openSite failed', err);
     return { ok: false, error: outputMessage('open_website_failed', outputLanguage) };
+  }
+}
+
+async function resetAssistantSessionForTabNavigation(tabId, url) {
+  if (!tabId) return;
+  const nextHost = hostForUrl(url);
+  if (!nextHost) return;
+  const existing = await getAssistantSession(tabId);
+  if (!existing || !existing.host) return;
+  if (existing.host !== nextHost) {
+    await clearAssistantSession(tabId);
   }
 }
 
@@ -1088,6 +1752,16 @@ try {
         (changeInfo && changeInfo.url) ||
         (tab && (tab.pendingUrl || tab.url) ? String(tab.pendingUrl || tab.url) : '');
       redirectNewTabToNavable(tabId, url);
+      resetAssistantSessionForTabNavigation(tabId, url).catch(() => {
+        // ignore session reset failures
+      });
+    });
+  }
+  if (chrome?.tabs?.onRemoved?.addListener) {
+    chrome.tabs.onRemoved.addListener((tabId) => {
+      clearAssistantSession(tabId).catch(() => {
+        // ignore session cleanup failures
+      });
     });
   }
 } catch (_err) {
@@ -1109,15 +1783,19 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
   if (msg && msg.type === 'navable:assistant') {
     requestAssistant(msg.input || '', msg.outputLanguage, {
+      purpose: msg.purpose || 'auto',
       includePageContext: !!msg.pageContext,
       pageStructure: msg.pageStructure || null,
-      sourceTabId
+      sourceTabId,
+      detectedLanguage: msg.detectedLanguage || '',
+      recognitionProvider: msg.recognitionProvider || '',
+      pageUrl: msg.pageUrl || ''
     }).then(async (res) => {
       if (
         res &&
         res.ok === true &&
         msg.autoExecutePlan !== false &&
-        msg.pageContext &&
+        (msg.pageContext || res.mode === 'page') &&
         res.plan &&
         res.plan.steps &&
         res.plan.steps.length

--- a/src/content.js
+++ b/src/content.js
@@ -577,6 +577,7 @@
     if (isNavableUiElement(active)) active = null;
     var activeId = active && active.dataset ? active.dataset.navableId : null;
     var activeLabel = '';
+    var sensitiveInputCount = 0;
     if (active) activeLabel = textOf(active);
     var headings = [];
     var links = [];
@@ -608,6 +609,7 @@
         if (el) {
           if (isSensitiveInput(el)) {
             // Exclude sensitive fields (e.g., passwords, card numbers) from the snapshot.
+            sensitiveInputCount += 1;
             return;
           }
           entry.inputType = (el.getAttribute && el.getAttribute('type')) || (el.tagName || '').toLowerCase();
@@ -626,6 +628,10 @@
       activeId: activeId,
       activeLabel: activeLabel || '',
       landmarks: landmarks,
+      privacy: {
+        sensitiveInputCount: sensitiveInputCount,
+        sensitivePage: sensitiveInputCount > 0
+      },
       counts: {
         headings: headings.length,
         links: links.length,
@@ -1151,8 +1157,34 @@
     return null;
   }
 
-  function extractOpenSiteQuery(t) {
+  function stripOpenIntentPrefixes(t) {
     var s = String(t || '').trim().toLowerCase();
+    if (!s) return '';
+
+    var patterns = [
+      /^(?:hey\s+navable|navable|please|pls)\b[\s,]*/,
+      /^(?:can you|could you|would you|will you)\b[\s,]*/,
+      /^(?:peux[- ]?tu|pourrais[- ]?tu|tu peux|svp|stp|s['’]?il te pla[îi]t)\b[\s,]*/,
+      /^(?:لو سمحت|من فضلك|رجاءً?|رجاء|ممكن|بتقدر|تقدر)\b[\s،]*/
+    ];
+
+    var changed = true;
+    while (changed) {
+      changed = false;
+      for (var i = 0; i < patterns.length; i += 1) {
+        var next = s.replace(patterns[i], '').trim();
+        if (next !== s) {
+          s = next;
+          changed = true;
+        }
+      }
+    }
+
+    return s;
+  }
+
+  function extractOpenSiteQuery(t) {
+    var s = stripOpenIntentPrefixes(t);
     if (!s) return null;
 
     // Avoid conflicting with in-page intents like "open first link" or "press button".
@@ -1169,7 +1201,7 @@
         .trim()
         .replace(/^(le|la|les|un|une)\b/, '')
         .trim()
-        .replace(/^(site|page|onglet)\b/, '')
+        .replace(/^(site|page|onglet|application|appli)\b/, '')
         .trim();
     }
 
@@ -1185,7 +1217,9 @@
       .trim()
       .replace(/^(new\s+)?tab\b/, '')
       .trim()
-      .replace(/^(website|site|page)\b/, '')
+      .replace(/^(website|site|page|app)\b/, '')
+      .trim()
+      .replace(/\bfor me\b/g, '')
       .trim()
       .replace(/\bplease\b/g, '')
       .trim();
@@ -1194,6 +1228,143 @@
     // If the remainder looks like another command, ignore.
     if (/^(scroll|read|focus|press|activate|next|previous|prev|repeat|stop)\b/.test(q)) return null;
     return q;
+  }
+
+  function isSummaryCommandText(text) {
+    var t = String(text || '').toLowerCase();
+    if (!t) return false;
+    return (
+      t.includes('summarize') ||
+      t.includes('summary') ||
+      t.includes('describe this page') ||
+      t.includes('what is this page') ||
+      t.includes("what's on this page") ||
+      t.includes('what is on this page') ||
+      t.includes("what's this page") ||
+      /r[ée]sum[ée]?.*cette page/.test(t) ||
+      /d[ée]cri(s|re).*cette page/.test(t) ||
+      /c[' ]?est quoi cette page/.test(t) ||
+      /qu[' ]?est[- ]ce que cette page/.test(t) ||
+      /ما هذه الصفحه/.test(t) ||
+      /ما هذه الصفحة/.test(t) ||
+      /ما هو محتوى الصفحة/.test(t) ||
+      /ملخص/.test(t) ||
+      /وصف الصفحة|صفحة شو هاي|شو هاي الصفحة|ايش هاي الصفحة|شو موجود هون|احكيلي عن الصفحة|اعطيني ملخص/.test(t)
+    );
+  }
+
+  function isPageAssistantQuestionText(text) {
+    var t = String(text || '').trim().toLowerCase();
+    if (!t) return false;
+    if (isSummaryCommandText(t)) return true;
+    return (
+      /\b(where am i|help me here|help on this page|help on this site|what can i do here|what can i do on this page|what can i do on this site|what is important here|what's important here|what is important on this page|what's important on this page|tell me about this page|tell me about the page|guide me here|what am i looking at|what is on this screen|what's on this screen|what is here|what's here)\b/.test(t) ||
+      /\b(o[uù] suis[- ]?je|aide[- ]?moi ici|que puis[- ]je faire ici|que puis[- ]je faire sur cette page|qu[' ]?est[- ]ce qui est important ici|qu[' ]?est[- ]ce qui est important sur cette page|parle[- ]?moi de cette page|guide[- ]?moi ici|qu[' ]?y a[- ]t[- ]il ici)\b/.test(t) ||
+      /(أين أنا|اين انا|ساعدني هنا|ساعدني هون|ماذا يمكنني أن أفعل هنا|ماذا يمكنني ان افعل هنا|شو المهم هون|ايش المهم هون|شو المهم هنا|ايش المهم هنا|احكيلي عن (?:هاي|هذه) الصفحة|احكيلي عن ه(?:اي|ذا) الموقع|دلني هون|دلني هنا|وجهني هون|وجهني هنا|شو في هون|ايش في هون|شو الموجود هون|ايش الموجود هون)/.test(t)
+    );
+  }
+
+  function isSessionFollowUpText(text) {
+    var t = String(text || '').trim().toLowerCase();
+    if (!t) return false;
+    return (
+      /^(tell me more|more detail|more details|go on|continue|keep going|expand that|what about that|what about it|and then)\b/.test(t) ||
+      /^(dis[- ]?m[' ]?en plus|plus de d[ée]tails|continue|vas[- ]?y|et ensuite)\b/.test(t) ||
+      /^(احكيلي اكثر|احكيلي المزيد|زيدني|كم[ّ]?ل|كمل|ماذا عن ذلك|شو كمان|ايش كمان)\b/.test(t)
+    );
+  }
+
+  var localAssistantSession = null;
+
+  function trimAssistantMemoryText(text, maxLen) {
+    var raw = String(text || '').replace(/\s+/g, ' ').trim();
+    var limit = typeof maxLen === 'number' ? maxLen : 240;
+    if (!raw) return '';
+    return raw.length > limit ? (raw.slice(0, Math.max(0, limit - 3)).trim() + '...') : raw;
+  }
+
+  function extractAssistantEntity(text) {
+    var raw = trimAssistantMemoryText(text, 160);
+    if (!raw || isSessionFollowUpText(raw)) return '';
+    return trimAssistantMemoryText(
+      raw
+        .replace(/^[“"'`]+|[”"'`]+$/g, '')
+        .replace(/^(who|what|when|where|why|how)\s+(is|are|was|were)\s+/i, '')
+        .replace(/^(explain|define|compare|tell me about|more about|what about)\s+/i, '')
+        .replace(/^(qui|que|qu[' ]?est[- ]?ce que|qu[' ]?est-ce que|explique|definis|définis|compare|parle[- ]?moi de|dis[- ]?moi)\s+/i, '')
+        .replace(/^(من|ما هو|ما هي|ما|اشرح|عر[ّ]ف|عرف|احكيلي عن|قل لي عن|خبرني عن|شو هو|ايش هو)\s+/i, '')
+        .replace(/^(the|a|an|le|la|les|un|une|ال)\s+/i, '')
+        .replace(/[?!.]+$/g, ''),
+      80
+    );
+  }
+
+  function buildLocalAssistantPageMemory(structure, summaryText) {
+    if (!structure) return null;
+    var privacy = structure && structure.privacy ? structure.privacy : {};
+    var sensitive = !!(privacy && (privacy.sensitivePage || Number(privacy.sensitiveInputCount || 0) > 0));
+    return {
+      url: trimAssistantMemoryText(structure.url, 280),
+      host: (function () {
+        try { return new URL(String(structure.url || '')).hostname.toLowerCase(); } catch (_err) { return ''; }
+      })(),
+      title: trimAssistantMemoryText(structure.title, 120),
+      topHeading: trimAssistantMemoryText(structure && structure.headings && structure.headings[0] ? structure.headings[0].label : '', 120),
+      activeLabel: sensitive ? '' : trimAssistantMemoryText(structure.activeLabel, 120),
+      summary: sensitive ? '' : trimAssistantMemoryText(summaryText, 260),
+      sensitivePage: sensitive,
+      sensitiveInputCount: Math.max(0, Number(privacy.sensitiveInputCount || 0))
+    };
+  }
+
+  function buildLocalAssistantSessionContext() {
+    if (!localAssistantSession) return null;
+    return {
+      lastPurpose: localAssistantSession.lastPurpose || '',
+      lastUserUtterance: localAssistantSession.lastUserUtterance || '',
+      lastEntity: localAssistantSession.lastEntity || '',
+      lastAssistantReply: localAssistantSession.lastAssistantReply || '',
+      lastAnswer: localAssistantSession.lastAnswer || '',
+      lastPage: localAssistantSession.lastPage || null,
+      lastAction: localAssistantSession.lastAction || '',
+      outputLanguage: localAssistantSession.outputLanguage || '',
+      detectedLanguage: localAssistantSession.detectedLanguage || '',
+      recognitionProvider: localAssistantSession.recognitionProvider || '',
+      domainHabits: null
+    };
+  }
+
+  function rememberLocalAssistantTurn(info) {
+    var existing = localAssistantSession || {};
+    var purpose = info && info.purpose ? String(info.purpose) : (existing.lastPurpose || '');
+    var speech = trimAssistantMemoryText((info && (info.speech || info.description)) || '', 260);
+    var answer = trimAssistantMemoryText((info && info.answer) || '', 260);
+    var summary = trimAssistantMemoryText((info && info.summary) || '', 260);
+    var structure = info && info.structure ? info.structure : null;
+    localAssistantSession = {
+      lastPurpose: purpose || existing.lastPurpose || '',
+      lastUserUtterance: trimAssistantMemoryText(info && info.input, 180) || existing.lastUserUtterance || '',
+      lastEntity: extractAssistantEntity(info && info.input) || existing.lastEntity || '',
+      lastAssistantReply: speech || answer || summary || existing.lastAssistantReply || '',
+      lastAnswer: answer || existing.lastAnswer || '',
+      lastPage: structure ? buildLocalAssistantPageMemory(structure, summary || speech) : (existing.lastPage || null),
+      lastAction: existing.lastAction || '',
+      outputLanguage: trimAssistantMemoryText(info && info.outputLanguage, 24) || existing.outputLanguage || '',
+      detectedLanguage: trimAssistantMemoryText(info && info.detectedLanguage, 24) || existing.detectedLanguage || '',
+      recognitionProvider: trimAssistantMemoryText(info && info.recognitionProvider, 24) || existing.recognitionProvider || ''
+    };
+  }
+
+  function assistantPurposeForText(text, sessionContext) {
+    if (isSummaryCommandText(text)) return 'summary';
+    if (isPageAssistantQuestionText(text)) return 'page';
+    if (isSessionFollowUpText(text)) {
+      var priorPurpose = sessionContext && sessionContext.lastPurpose ? String(sessionContext.lastPurpose).trim().toLowerCase() : '';
+      if (priorPurpose === 'summary' || priorPurpose === 'page') return 'page';
+      if (priorPurpose === 'answer') return 'answer';
+      return 'auto';
+    }
+    return 'answer';
   }
 
   function parseCommand(text) {
@@ -1212,24 +1383,7 @@
     }
 
     // Summary/orientation triggers in English, French, and Arabic.
-    if (
-      t.includes('summarize') ||
-      t.includes('summary') ||
-      t.includes('describe this page') ||
-      t.includes('what is this page') ||
-      t.includes("what's on this page") ||
-      t.includes('what is on this page') ||
-      t.includes("what's this page") ||
-      /r[ée]sum[ée]?.*cette page/.test(t) ||
-      /d[ée]cri(s|re).*cette page/.test(t) ||
-      /c[' ]?est quoi cette page/.test(t) ||
-      /qu[' ]?est[- ]ce que cette page/.test(t) ||
-      /ما هذه الصفحه/.test(t) ||
-      /ما هذه الصفحة/.test(t) ||
-      /ما هو محتوى الصفحة/.test(t) ||
-      /ملخص/.test(t) ||
-      /وصف الصفحة|صفحة شو هاي|شو هاي الصفحة|ايش هاي الصفحة|شو موجود هون|احكيلي عن الصفحة|اعطيني ملخص/.test(t)
-    ) {
+    if (isSummaryCommandText(t)) {
       return { type: 'summarize', command: original || 'Summarize this page' };
     }
 
@@ -1621,10 +1775,14 @@
     }
   }
 
-  async function assistantRequest(questionText, pageStructure) {
+  async function assistantRequest(questionText, pageStructure, turnContext) {
     var q = String(questionText || '').trim();
     if (!q) return false;
-    var structure = pageStructure || buildPageContextSnapshot();
+    var context = turnContext || {};
+    var sessionContext = buildLocalAssistantSessionContext();
+    var purpose = assistantPurposeForText(q, sessionContext);
+    var wantsPageContext = purpose === 'summary' || purpose === 'page';
+    var structure = wantsPageContext ? (pageStructure || buildPageContextSnapshot()) : null;
 
     await ensureOutputLanguageReady();
     speakTransient(translate('answering_question'), 2500);
@@ -1635,11 +1793,27 @@
           type: 'navable:assistant',
           input: q,
           outputLanguage: currentOutputLanguage(),
-          pageContext: true,
+          purpose: purpose,
+          pageContext: wantsPageContext,
           pageStructure: structure,
-          autoExecutePlan: true
+          autoExecutePlan: wantsPageContext,
+          detectedLanguage: context.detectedLanguage || '',
+          recognitionProvider: context.recognitionProvider || '',
+          pageUrl: structure && structure.url ? structure.url : location.href
         });
         if (res && res.ok === true && res.speech) {
+          var rememberedPurpose = purpose === 'auto' ? (res.mode === 'page' ? 'page' : 'answer') : purpose;
+          rememberLocalAssistantTurn({
+            input: q,
+            purpose: rememberedPurpose,
+            structure: structure,
+            speech: res.speech,
+            summary: res.summary || '',
+            answer: res.answer || '',
+            outputLanguage: currentOutputLanguage(),
+            detectedLanguage: context.detectedLanguage || '',
+            recognitionProvider: context.recognitionProvider || ''
+          });
           speak(String(res.speech), { mode: 'assertive' });
           return true;
         }
@@ -1658,14 +1832,38 @@
         body: JSON.stringify({
           input: q,
           outputLanguage: currentOutputLanguage(),
-          pageStructure: structure
+          pageStructure: structure,
+          purpose: purpose,
+          sessionContext: sessionContext
         })
       });
       var directData = await directResponse.json().catch(function () { return {}; });
+      if (
+        directResponse.ok &&
+        directData &&
+        directData.action &&
+        directData.action.type === 'open_site' &&
+        directData.action.query
+      ) {
+        await openSiteRequest(directData.action.query, directData.action.newTab !== false);
+        return true;
+      }
       if (directResponse.ok && directData && directData.speech) {
-        if (directData.plan && Array.isArray(directData.plan.steps) && directData.plan.steps.length) {
+        if (wantsPageContext && directData.plan && Array.isArray(directData.plan.steps) && directData.plan.steps.length) {
           await runPlan(directData.plan);
         }
+        var directRememberedPurpose = purpose === 'auto' ? (directData.mode === 'page' ? 'page' : 'answer') : purpose;
+        rememberLocalAssistantTurn({
+          input: q,
+          purpose: directRememberedPurpose,
+          structure: structure,
+          speech: directData.speech,
+          summary: directData.summary || '',
+          answer: directData.answer || '',
+          outputLanguage: currentOutputLanguage(),
+          detectedLanguage: context.detectedLanguage || '',
+          recognitionProvider: context.recognitionProvider || ''
+        });
         speak(String(directData.speech), { mode: 'assertive' });
         return true;
       }
@@ -1721,7 +1919,10 @@
         return true;
       }
       if (await tryIntentFallback(text, pageStructure)) return true;
-      if (await assistantRequest(text, pageStructure)) return true;
+      if (await assistantRequest(text, pageStructure, {
+        detectedLanguage: detectedLanguage || '',
+        recognitionProvider: provider || ''
+      })) return true;
       await languageReady;
       execCommand(null);
       return true;

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -231,8 +231,34 @@ function getVoiceStatusEls() {
   };
 }
 
+function stripOpenIntentPrefixes(transcript) {
+  let s = String(transcript || '').trim().toLowerCase();
+  if (!s) return '';
+
+  const patterns = [
+    /^(?:hey\s+navable|navable|please|pls)\b[\s,]*/,
+    /^(?:can you|could you|would you|will you)\b[\s,]*/,
+    /^(?:peux[- ]?tu|pourrais[- ]?tu|tu peux|svp|stp|s['’]?il te pla[îi]t)\b[\s,]*/,
+    /^(?:لو سمحت|من فضلك|رجاءً?|رجاء|ممكن|بتقدر|تقدر)\b[\s،]*/
+  ];
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const pattern of patterns) {
+      const next = s.replace(pattern, '').trim();
+      if (next !== s) {
+        s = next;
+        changed = true;
+      }
+    }
+  }
+
+  return s;
+}
+
 function extractOpenSiteQuery(transcript) {
-  const s = String(transcript || '').trim().toLowerCase();
+  const s = stripOpenIntentPrefixes(transcript);
   if (!s) return null;
 
   // Arabic website intents.
@@ -246,7 +272,7 @@ function extractOpenSiteQuery(transcript) {
       .trim()
       .replace(/^(le|la|les|un|une)\b/, '')
       .trim()
-      .replace(/^(site|page|onglet)\b/, '')
+      .replace(/^(site|page|onglet|application|appli)\b/, '')
       .trim();
   }
 
@@ -262,7 +288,9 @@ function extractOpenSiteQuery(transcript) {
     .trim()
     .replace(/^(new\s+)?tab\b/, '')
     .trim()
-    .replace(/^(website|site|page)\b/, '')
+    .replace(/^(website|site|page|app)\b/, '')
+    .trim()
+    .replace(/\bfor me\b/g, '')
     .trim()
     .replace(/\bplease\b/g, '')
     .trim();
@@ -309,6 +337,84 @@ function parseVoiceCommand(transcript) {
   if (q) return { type: 'open_site', query: q };
 
   return null;
+}
+
+function isSessionFollowUpText(text) {
+  const t = String(text || '').trim().toLowerCase();
+  if (!t) return false;
+  return (
+    /^(tell me more|more detail|more details|go on|continue|keep going|expand that|what about that|what about it|and then)\b/.test(t) ||
+    /^(dis[- ]?m[' ]?en plus|plus de d[ée]tails|continue|vas[- ]?y|et ensuite)\b/.test(t) ||
+    /^(احكيلي اكثر|احكيلي المزيد|زيدني|كم[ّ]?ل|كمل|ماذا عن ذلك|شو كمان|ايش كمان)\b/.test(t)
+  );
+}
+
+let newtabAssistantSession = null;
+
+function trimAssistantMemoryText(text, maxLen = 240) {
+  const raw = String(text || '').replace(/\s+/g, ' ').trim();
+  if (!raw) return '';
+  return raw.length > maxLen ? `${raw.slice(0, Math.max(0, maxLen - 3)).trim()}...` : raw;
+}
+
+function extractAssistantEntity(text) {
+  const raw = trimAssistantMemoryText(text, 160);
+  if (!raw || isSessionFollowUpText(raw)) return '';
+  return trimAssistantMemoryText(
+    raw
+      .replace(/^[“"'`]+|[”"'`]+$/g, '')
+      .replace(/^(who|what|when|where|why|how)\s+(is|are|was|were)\s+/i, '')
+      .replace(/^(explain|define|compare|tell me about|more about|what about)\s+/i, '')
+      .replace(/^(qui|que|qu[' ]?est[- ]?ce que|qu[' ]?est-ce que|explique|definis|définis|compare|parle[- ]?moi de|dis[- ]?moi)\s+/i, '')
+      .replace(/^(من|ما هو|ما هي|ما|اشرح|عر[ّ]ف|عرف|احكيلي عن|قل لي عن|خبرني عن|شو هو|ايش هو)\s+/i, '')
+      .replace(/^(the|a|an|le|la|les|un|une|ال)\s+/i, '')
+      .replace(/[?!.]+$/g, ''),
+    80
+  );
+}
+
+function buildNewtabAssistantSessionContext() {
+  if (!newtabAssistantSession) return null;
+  return {
+    lastPurpose: newtabAssistantSession.lastPurpose || '',
+    lastUserUtterance: newtabAssistantSession.lastUserUtterance || '',
+    lastEntity: newtabAssistantSession.lastEntity || '',
+    lastAssistantReply: newtabAssistantSession.lastAssistantReply || '',
+    lastAnswer: newtabAssistantSession.lastAnswer || '',
+    lastPage: null,
+    lastAction: newtabAssistantSession.lastAction || '',
+    outputLanguage: newtabAssistantSession.outputLanguage || '',
+    detectedLanguage: newtabAssistantSession.detectedLanguage || '',
+    recognitionProvider: newtabAssistantSession.recognitionProvider || '',
+    domainHabits: null
+  };
+}
+
+function rememberNewtabAssistantTurn(info = {}) {
+  const existing = newtabAssistantSession || {};
+  const purpose = info.purpose || existing.lastPurpose || '';
+  const speech = trimAssistantMemoryText(info.speech || info.description, 260);
+  const answer = trimAssistantMemoryText(info.answer, 260);
+  newtabAssistantSession = {
+    lastPurpose: purpose,
+    lastUserUtterance: trimAssistantMemoryText(info.input, 180) || existing.lastUserUtterance || '',
+    lastEntity: extractAssistantEntity(info.input) || existing.lastEntity || '',
+    lastAssistantReply: speech || answer || existing.lastAssistantReply || '',
+    lastAnswer: answer || existing.lastAnswer || '',
+    lastAction: existing.lastAction || '',
+    outputLanguage: trimAssistantMemoryText(info.outputLanguage, 24) || existing.outputLanguage || '',
+    detectedLanguage: trimAssistantMemoryText(info.detectedLanguage, 24) || existing.detectedLanguage || '',
+    recognitionProvider: trimAssistantMemoryText(info.recognitionProvider, 24) || existing.recognitionProvider || ''
+  };
+}
+
+function assistantQuestionPurposeForText(text, sessionContext = null) {
+  if (!isSessionFollowUpText(text)) return 'answer';
+  const priorPurpose = sessionContext && sessionContext.lastPurpose
+    ? String(sessionContext.lastPurpose).trim().toLowerCase()
+    : '';
+  if (priorPurpose === 'answer') return 'answer';
+  return 'auto';
 }
 
 let newtabRecognizer = null;
@@ -670,9 +776,11 @@ async function openSiteFromVoice(query) {
   await openUrl(url);
 }
 
-async function assistantQuestionFromVoice(questionText) {
+async function assistantQuestionFromVoice(questionText, turnContext = {}) {
   const q = String(questionText || '').trim();
   if (!q) return false;
+  const sessionContext = buildNewtabAssistantSessionContext();
+  const purpose = assistantQuestionPurposeForText(q, sessionContext);
 
   await ensureOutputLanguageReady();
   setNewtabMicMessage(translate('answering_question'), 'polite');
@@ -683,10 +791,23 @@ async function assistantQuestionFromVoice(questionText) {
         type: 'navable:assistant',
         input: q,
         outputLanguage: currentOutputLanguage(),
+        purpose,
         pageContext: false,
-        autoExecutePlan: false
+        autoExecutePlan: false,
+        detectedLanguage: turnContext.detectedLanguage || '',
+        recognitionProvider: turnContext.recognitionProvider || ''
       });
       if (res?.ok && res.speech) {
+        const rememberedPurpose = purpose === 'auto' ? (res.mode === 'page' ? 'page' : 'answer') : purpose;
+        rememberNewtabAssistantTurn({
+          input: q,
+          purpose: rememberedPurpose,
+          speech: res.speech,
+          answer: res.answer || '',
+          outputLanguage: currentOutputLanguage(),
+          detectedLanguage: turnContext.detectedLanguage || '',
+          recognitionProvider: turnContext.recognitionProvider || ''
+        });
         setNewtabMicMessage(String(res.speech), 'assertive');
         return true;
       }
@@ -704,11 +825,27 @@ async function assistantQuestionFromVoice(questionText) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         input: q,
-        outputLanguage: currentOutputLanguage()
+        outputLanguage: currentOutputLanguage(),
+        purpose,
+        sessionContext
       })
     });
     const data = await response.json().catch(() => ({}));
+    if (response.ok && data?.action?.type === 'open_site' && data.action.query) {
+      await openSiteFromVoice(data.action.query);
+      return true;
+    }
     if (response.ok && data?.speech) {
+      const rememberedPurpose = purpose === 'auto' ? (data.mode === 'page' ? 'page' : 'answer') : purpose;
+      rememberNewtabAssistantTurn({
+        input: q,
+        purpose: rememberedPurpose,
+        speech: data.speech,
+        answer: data.answer || '',
+        outputLanguage: currentOutputLanguage(),
+        detectedLanguage: turnContext.detectedLanguage || '',
+        recognitionProvider: turnContext.recognitionProvider || ''
+      });
       setNewtabMicMessage(String(data.speech), 'assertive');
       return true;
     }
@@ -733,7 +870,10 @@ async function handleNewtabTranscript(transcript, detectedLanguage, provider) {
     const languageReady = ensureOutputLanguageReady();
     const cmd = parseVoiceCommand(transcript);
     if (!cmd) {
-      if (await assistantQuestionFromVoice(transcript)) return true;
+      if (await assistantQuestionFromVoice(transcript, {
+        detectedLanguage: detectedLanguage || '',
+        recognitionProvider: provider || ''
+      })) return true;
       await languageReady;
       setNewtabMicMessage(translate('newtab_try_open'), 'polite');
       return true;

--- a/tests/backend-follow-up.spec.ts
+++ b/tests/backend-follow-up.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import {
   isClarifyingAnswerText,
   resolveAnswerQuestionWithSessionContext
-} from '../backend/src/server.js';
+} from '../backend/src/assistant-session.js';
 
 test('answer follow-ups resolve to the prior entity', async () => {
   const resolved = resolveAnswerQuestionWithSessionContext('tell me more', {

--- a/tests/backend-follow-up.spec.ts
+++ b/tests/backend-follow-up.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+import {
+  isClarifyingAnswerText,
+  resolveAnswerQuestionWithSessionContext
+} from '../backend/src/server.js';
+
+test('answer follow-ups resolve to the prior entity', async () => {
+  const resolved = resolveAnswerQuestionWithSessionContext('tell me more', {
+    lastPurpose: 'answer',
+    lastEntity: 'moon',
+    lastUserUtterance: 'What is the moon?',
+    lastAnswer: "The moon is Earth's natural satellite."
+  });
+
+  expect(resolved.resolvedFromSession).toBe(true);
+  expect(resolved.topic).toBe('moon');
+  expect(resolved.resolvedQuestion).toBe('Tell me more about moon.');
+});
+
+test('pronoun questions reuse the prior entity', async () => {
+  const resolved = resolveAnswerQuestionWithSessionContext('what about its orbit?', {
+    lastPurpose: 'answer',
+    lastEntity: 'moon',
+    lastUserUtterance: 'What is the moon?',
+    lastAnswer: "The moon is Earth's natural satellite."
+  });
+
+  expect(resolved.resolvedFromSession).toBe(true);
+  expect(resolved.resolvedQuestion).toBe("what about moon's orbit?");
+});
+
+test('clarifying follow-up answers are detected for retry', async () => {
+  expect(isClarifyingAnswerText('Could you please specify the topic you want to know more about?')).toBe(true);
+  expect(isClarifyingAnswerText('The moon affects tides on Earth.')).toBe(false);
+});

--- a/tests/background-routing.spec.ts
+++ b/tests/background-routing.spec.ts
@@ -42,7 +42,7 @@ test('runPlanner executes steps on the sender tab when provided', async ({ page 
   expect(result.calls[0].payload.type).toBe('navable:executePlan');
 });
 
-test('assistant runtime requests execute plans on the sender tab without re-querying the active tab', async ({ page }) => {
+test('page-context assistant runtime requests execute plans on the sender tab without re-querying the active tab', async ({ page }) => {
   await page.addScriptTag({ path: 'src/background.js' });
 
   const result = await page.evaluate(async () => {
@@ -64,8 +64,11 @@ test('assistant runtime requests execute plans on the sender tab without re-quer
       }
 
       const body = JSON.parse(String(init?.body || '{}'));
-      if (body.input !== 'What is the moon?') {
+      if (body.input !== 'help me here') {
         throw new Error(`Unexpected input: ${String(body.input || '')}`);
+      }
+      if (body.purpose !== 'page') {
+        throw new Error(`Unexpected purpose: ${String(body.purpose || '')}`);
       }
       if (!body.pageStructure || body.pageStructure.title !== 'Docs') {
         throw new Error('Missing sender page structure');
@@ -75,10 +78,10 @@ test('assistant runtime requests execute plans on the sender tab without re-quer
         ok: true,
         async json() {
           return {
-            mode: 'answer',
-            speech: "The moon is Earth's natural satellite.",
-            summary: '',
-            answer: "The moon is Earth's natural satellite.",
+            mode: 'page',
+            speech: 'You are on the docs page.',
+            summary: 'You are on the docs page.',
+            answer: '',
             suggestions: [],
             plan: { steps: [{ action: 'scroll', direction: 'down' }] }
           };
@@ -93,8 +96,9 @@ test('assistant runtime requests execute plans on the sender tab without re-quer
         const maybeAsync = listener(
           {
             type: 'navable:assistant',
-            input: 'What is the moon?',
+            input: 'help me here',
             outputLanguage: 'en',
+            purpose: 'page',
             pageContext: true,
             pageStructure: {
               title: 'Docs',
@@ -120,13 +124,126 @@ test('assistant runtime requests execute plans on the sender tab without re-quer
     return { response, calls };
   });
 
-  expect(result.response).toMatchObject({ ok: true, speech: "The moon is Earth's natural satellite." });
+  expect(result.response).toMatchObject({ ok: true, speech: 'You are on the docs page.' });
   expect(result.calls).toHaveLength(1);
   expect(result.calls[0].tabId).toBe(42);
   expect(result.calls[0].payload.type).toBe('navable:executePlan');
 });
 
-test('content assistant requests include the current page structure', async ({ page }) => {
+test('assistant runtime requests carry session memory into answer follow-ups', async ({ page }) => {
+  await page.addScriptTag({ path: 'src/background.js' });
+
+  const result = await page.evaluate(async () => {
+    const requestBodies: any[] = [];
+    let sessionGetCalls = 0;
+    let firstStoredSession: any = null;
+
+    const originalSessionGet = window.chrome.storage.session.get.bind(window.chrome.storage.session);
+    // @ts-ignore
+    window.chrome.storage.session.get = (query: any, cb: (res: any) => void) => {
+      sessionGetCalls += 1;
+      originalSessionGet(query, cb);
+    };
+
+    window.fetch = async (url, init) => {
+      if (!String(url).includes('/api/assistant')) {
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      }
+
+      const body = JSON.parse(String(init?.body || '{}'));
+      requestBodies.push(body);
+
+      if (body.input === 'What is the moon?') {
+        return {
+          ok: true,
+          async json() {
+            return {
+              mode: 'answer',
+              speech: "The moon is Earth's natural satellite.",
+              summary: '',
+              answer: "The moon is Earth's natural satellite.",
+              suggestions: [],
+              plan: { steps: [] }
+            };
+          }
+        };
+      }
+
+      if (body.input === 'tell me more') {
+        return {
+          ok: true,
+          async json() {
+            return {
+              mode: 'answer',
+              speech: 'It affects tides and stabilizes Earths axial tilt.',
+              summary: '',
+              answer: 'It affects tides and stabilizes Earths axial tilt.',
+              suggestions: [],
+              plan: { steps: [] }
+            };
+          }
+        };
+      }
+
+      throw new Error(`Unexpected input: ${String(body.input || '')}`);
+    };
+
+    // @ts-ignore
+    const listener = window.chrome.runtime._listeners[window.chrome.runtime._listeners.length - 1];
+
+    async function sendAssistant(payload: any) {
+      return await new Promise((resolve, reject) => {
+        try {
+          const maybeAsync = listener(payload, { tab: { id: 42 } }, resolve);
+          if (maybeAsync !== true) resolve(undefined);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }
+
+    await sendAssistant({
+      type: 'navable:assistant',
+      input: 'What is the moon?',
+      outputLanguage: 'en',
+      purpose: 'answer',
+      pageContext: false,
+      autoExecutePlan: false
+    });
+    firstStoredSession = window.chrome.storage.session._data['navable.session.42'];
+
+    await sendAssistant({
+      type: 'navable:assistant',
+      input: 'tell me more',
+      outputLanguage: 'en',
+      purpose: 'auto',
+      pageContext: false,
+      autoExecutePlan: false
+    });
+
+    return {
+      requestBodies,
+      firstStoredSession,
+      storedSession: window.chrome.storage.session._data['navable.session.42'],
+      sessionGetCalls
+    };
+  });
+
+  expect(result.requestBodies[0].purpose).toBe('answer');
+  expect(result.requestBodies[0].sessionContext).toBeNull();
+  expect(result.requestBodies[1].purpose).toBe('answer');
+  expect(result.requestBodies[1].pageStructure).toBeNull();
+  expect(result.requestBodies[1].sessionContext?.lastPurpose).toBe('answer');
+  expect(result.requestBodies[1].sessionContext?.lastAnswer).toContain("Earth's natural satellite");
+  expect(result.requestBodies[1].sessionContext?.lastEntity).toBe('moon');
+  expect(result.firstStoredSession?.lastPurpose).toBe('answer');
+  expect(result.firstStoredSession?.lastAnswer).toContain("Earth's natural satellite");
+  expect(result.storedSession?.lastPurpose).toBe('answer');
+  expect(result.storedSession?.lastAnswer).toContain('It affects tides');
+  expect(result.sessionGetCalls).toBeGreaterThan(0);
+});
+
+test('content assistant requests omit the current page structure for general questions', async ({ page }) => {
   await page.setContent(`
     <html>
       <head>
@@ -207,5 +324,91 @@ test('content assistant requests include the current page structure', async ({ p
   expect(captured[0].pageStructure.title).toBe('Docs');
   expect(captured[0].pageStructure.headings[0].label).toBe('Docs');
   expect(captured[1].type).toBe('navable:assistant');
+  expect(captured[1].purpose).toBe('answer');
+  expect(captured[1].pageContext).toBe(false);
+  expect(captured[1].pageStructure).toBeNull();
+});
+
+test('content assistant requests include the current page structure for explicit page help', async ({ page }) => {
+  await page.setContent(`
+    <html>
+      <head>
+        <title>Docs</title>
+      </head>
+      <body>
+        <main>
+          <h1>Docs</h1>
+          <p>Welcome to the docs.</p>
+          <h2>Getting Started</h2>
+        </main>
+      </body>
+    </html>
+  `);
+
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+
+  await page.evaluate(() => {
+    const messages: any[] = [];
+    // @ts-ignore
+    window.chrome = {
+      runtime: {
+        sendMessage: async (payload: any) => {
+          messages.push(payload);
+          return {
+            ok: true,
+            speech: 'You are on the docs page.',
+            plan: { steps: [] }
+          };
+        },
+        onMessage: {
+          addListener() {}
+        }
+      },
+      storage: {
+        sync: {
+          get(_defaults: any, cb: (res: any) => void) {
+            cb({ navable_settings: { language: 'en-US', autostart: false, overlay: false } });
+          }
+        },
+        onChanged: {
+          addListener() {}
+        }
+      }
+    };
+    // @ts-ignore
+    window.__capturedMessages = messages;
+    // @ts-ignore
+    window.NavableSpeech = {
+      supportsRecognition: () => true,
+      createRecognizer: () => ({
+        start() {},
+        stop() {},
+        on() { return this; }
+      })
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/content.js' });
+  await page.waitForFunction(() => (window as any).NavableTools?.handleTranscript);
+  await page.waitForFunction(() => {
+    // @ts-ignore
+    return (window as any).NavableTools?.buildPageStructure?.().title === 'Docs';
+  });
+
+  await page.evaluate(async () => {
+    // @ts-ignore
+    await (window as any).NavableTools.handleTranscript('help me here', 'en', 'native');
+  });
+
+  const captured = await page.evaluate(() => {
+    // @ts-ignore
+    return window.__capturedMessages;
+  });
+
+  expect(captured[0].type).toBe('planner:run');
+  expect(captured[1].type).toBe('navable:assistant');
+  expect(captured[1].purpose).toBe('page');
+  expect(captured[1].pageContext).toBe(true);
   expect(captured[1].pageStructure.title).toBe('Docs');
 });

--- a/tests/open-site.spec.ts
+++ b/tests/open-site.spec.ts
@@ -38,3 +38,69 @@ test('resolveOpenQueryToUrl supports spoken dot/slash, multilingual site aliases
   expect(urls.guessedHost).toBe('https://www.newyorktimes.com/');
   expect(urls.genericHost).toBe('https://www.weathertomorrow.com/');
 });
+
+test('requestAssistant treats polite open-site phrasing as an action', async ({ page }) => {
+  await page.addScriptTag({ path: 'src/background.js' });
+
+  const res = await page.evaluate(async () => {
+    const originalFetch = window.fetch;
+    // The direct routing should handle this before the backend assistant is called.
+    // @ts-ignore
+    window.fetch = async () => { throw new Error('backend assistant should not be called'); };
+    try {
+      // @ts-ignore - background.js defines this in the test context
+      return await (window as any).requestAssistant('can you please open facebook for me', 'en');
+    } finally {
+      window.fetch = originalFetch;
+    }
+  });
+
+  expect(res.ok).toBe(true);
+  expect(res.mode).toBe('action');
+  expect(res.action?.type).toBe('open_site');
+  expect(res.url).toContain('https://www.facebook.com');
+
+  const created = await page.evaluate(() => {
+    // @ts-ignore
+    return (window as any).chrome?.tabs?._created || [];
+  });
+  expect(created).toContain(res.url);
+});
+
+test('requestAssistant executes assistant-returned open-site actions instead of speaking a denial', async ({ page }) => {
+  await page.addScriptTag({ path: 'src/background.js' });
+
+  const res = await page.evaluate(async () => {
+    const originalFetch = window.fetch;
+    // @ts-ignore
+    window.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        mode: 'action',
+        speech: '',
+        summary: '',
+        answer: '',
+        suggestions: [],
+        plan: { steps: [] },
+        action: { type: 'open_site', query: 'facebook', newTab: true }
+      })
+    });
+    try {
+      // @ts-ignore - background.js defines this in the test context
+      return await (window as any).requestAssistant('خذني على فيسبوك', 'ar');
+    } finally {
+      window.fetch = originalFetch;
+    }
+  });
+
+  expect(res.ok).toBe(true);
+  expect(res.mode).toBe('action');
+  expect(res.action?.type).toBe('open_site');
+  expect(res.url).toContain('https://www.facebook.com');
+
+  const created = await page.evaluate(() => {
+    // @ts-ignore
+    return (window as any).chrome?.tabs?._created || [];
+  });
+  expect(created).toContain(res.url);
+});

--- a/tests/structure-and-plan.spec.ts
+++ b/tests/structure-and-plan.spec.ts
@@ -65,6 +65,8 @@ test('buildPageStructure excludes sensitive inputs from snapshot', async ({ page
   expect(structure.counts.inputs).toBe(1);
   const names = structure.inputs.map((i: any) => i.name).sort();
   expect(names).toEqual(['city']);
+  expect(structure.privacy?.sensitiveInputCount).toBe(2);
+  expect(structure.privacy?.sensitivePage).toBe(true);
 });
 
 test('buildPageStructure ignores Navable injected output UI', async ({ page }) => {

--- a/tests/voice-qa.spec.ts
+++ b/tests/voice-qa.spec.ts
@@ -67,6 +67,203 @@ test('unknown spoken question falls back to a brief AI answer', async ({ page })
   await expect(page.locator('#navable-output-text')).toHaveValue(/Ada Lovelace/);
 });
 
+test('short spoken questions on content tabs stay on the answer path', async ({ page }) => {
+  await page.setContent(`
+    <main>
+      <h1>Docs</h1>
+      <p>Welcome to the docs.</p>
+      <h2>Getting Started</h2>
+    </main>
+  `);
+
+  await page.evaluate(() => {
+    window.fetch = async (url, init) => {
+      if (!String(url).includes('/api/assistant')) {
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      }
+
+      const body = JSON.parse(String(init?.body || '{}'));
+      if (body.input !== 'moon facts') {
+        throw new Error(`Unexpected input: ${String(body.input || '')}`);
+      }
+      if (body.purpose !== 'answer') {
+        throw new Error(`Unexpected purpose: ${String(body.purpose || '')}`);
+      }
+      if (body.pageStructure) {
+        throw new Error('General questions should not include page structure');
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return {
+            mode: 'answer',
+            speech: "The moon is Earth's natural satellite.",
+            summary: '',
+            answer: "The moon is Earth's natural satellite.",
+            suggestions: [],
+            plan: { steps: [] }
+          };
+        }
+      };
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/background.js' });
+
+  await page.evaluate(() => {
+    // @ts-ignore
+    (window as any).chrome.storage.sync.get = (_defaults: any, cb: (res: any) => void) => {
+      cb({
+        navable_settings: {
+          aiEnabled: true,
+          aiMode: 'summary',
+          language: 'en-US',
+          autostart: false
+        }
+      });
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+  await page.addScriptTag({ path: 'src/common/speech.js' });
+  await page.addScriptTag({ path: 'src/content.js' });
+
+  await page.waitForFunction(() => (window as any).NavableTools?.handleTranscript);
+
+  await page.evaluate(async () => {
+    // @ts-ignore
+    await (window as any).NavableTools.handleTranscript('moon facts', 'en');
+  });
+
+  await expect(page.locator('#navable-live-region-assertive')).toContainText("Earth's natural satellite");
+  await expect(page.locator('#navable-output-text')).toHaveValue(/Earth's natural satellite/);
+});
+
+test('page follow-up questions reuse session memory on content tabs', async ({ page }) => {
+  await page.setContent(`
+    <main>
+      <h1>Docs</h1>
+      <p>Welcome to the docs.</p>
+      <h2>Getting Started</h2>
+    </main>
+  `);
+
+  await page.evaluate(() => {
+    let callCount = 0;
+
+    window.fetch = async (url, init) => {
+      if (!String(url).includes('/api/assistant')) {
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      }
+
+      callCount += 1;
+      const body = JSON.parse(String(init?.body || '{}'));
+
+      if (callCount === 1) {
+        if (body.input !== 'help me here') {
+          throw new Error(`Unexpected first input: ${String(body.input || '')}`);
+        }
+        if (body.purpose !== 'page') {
+          throw new Error(`Unexpected first purpose: ${String(body.purpose || '')}`);
+        }
+        if (
+          !body.pageStructure ||
+          !Array.isArray(body.pageStructure.headings) ||
+          body.pageStructure.headings[0]?.label !== 'Docs'
+        ) {
+          throw new Error('Missing first page structure');
+        }
+        if (body.sessionContext !== null) {
+          throw new Error('First page request should not have prior session context');
+        }
+
+        return {
+          ok: true,
+          async json() {
+            return {
+              mode: 'page',
+              speech: 'You are on the docs page.',
+              summary: 'You are on the docs page.',
+              answer: '',
+              suggestions: [],
+              plan: { steps: [] }
+            };
+          }
+        };
+      }
+
+      if (body.input !== 'tell me more') {
+        throw new Error(`Unexpected second input: ${String(body.input || '')}`);
+      }
+      if (body.purpose !== 'page') {
+        throw new Error(`Unexpected second purpose: ${String(body.purpose || '')}`);
+      }
+      if (
+        !body.pageStructure ||
+        !Array.isArray(body.pageStructure.headings) ||
+        body.pageStructure.headings[0]?.label !== 'Docs'
+      ) {
+        throw new Error('Missing follow-up page structure');
+      }
+      if (body.sessionContext?.lastPurpose !== 'page') {
+        throw new Error(`Missing follow-up purpose memory: ${String(body.sessionContext?.lastPurpose || '')}`);
+      }
+      if (!String(body.sessionContext?.lastPage?.summary || '').includes('docs page')) {
+        throw new Error('Missing prior page summary in session context');
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return {
+            mode: 'page',
+            speech: 'The Getting Started section explains setup.',
+            summary: 'The Getting Started section explains setup.',
+            answer: '',
+            suggestions: [],
+            plan: { steps: [] }
+          };
+        }
+      };
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/background.js' });
+
+  await page.evaluate(() => {
+    // @ts-ignore
+    (window as any).chrome.storage.sync.get = (_defaults: any, cb: (res: any) => void) => {
+      cb({
+        navable_settings: {
+          aiEnabled: true,
+          aiMode: 'summary',
+          language: 'en-US',
+          autostart: false
+        }
+      });
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+  await page.addScriptTag({ path: 'src/common/speech.js' });
+  await page.addScriptTag({ path: 'src/content.js' });
+
+  await page.waitForFunction(() => (window as any).NavableTools?.handleTranscript);
+
+  await page.evaluate(async () => {
+    // @ts-ignore
+    await (window as any).NavableTools.handleTranscript('help me here', 'en');
+    // @ts-ignore
+    await (window as any).NavableTools.handleTranscript('tell me more', 'en');
+  });
+
+  await expect(page.locator('#navable-output-text')).toHaveValue(/Getting Started/);
+  await expect(page.locator('#navable-output-text')).toHaveValue(/Getting Started/);
+});
+
 test('spoken question retries assistant directly when background returns a generic error', async ({ page }) => {
   await page.setContent(`
     <main>
@@ -137,6 +334,117 @@ test('spoken question retries assistant directly when background returns a gener
 
   await expect(page.locator('#navable-live-region-assertive')).toContainText("Earth's natural satellite");
   await expect(page.locator('#navable-output-text')).toHaveValue(/Earth's natural satellite/);
+});
+
+test('direct assistant fallback keeps session memory for follow-up questions', async ({ page }) => {
+  await page.setContent(`
+    <main>
+      <h1>Space</h1>
+      <p>The moon orbits Earth.</p>
+    </main>
+  `);
+
+  await page.evaluate(() => {
+    let callCount = 0;
+
+    window.fetch = async (url, init) => {
+      if (!String(url).includes('/api/assistant')) {
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      }
+
+      callCount += 1;
+      const body = JSON.parse(String(init?.body || '{}'));
+
+      if (callCount === 1) {
+        if (body.input !== 'What is the moon?') {
+          throw new Error(`Unexpected first input: ${String(body.input || '')}`);
+        }
+        if (body.sessionContext !== null) {
+          throw new Error('First direct fallback request should not have prior session context');
+        }
+        return {
+          ok: true,
+          async json() {
+            return {
+              mode: 'answer',
+              speech: "The moon is Earth's natural satellite.",
+              summary: '',
+              answer: "The moon is Earth's natural satellite.",
+              suggestions: [],
+              plan: { steps: [] }
+            };
+          }
+        };
+      }
+
+      if (body.input !== 'tell me more') {
+        throw new Error(`Unexpected second input: ${String(body.input || '')}`);
+      }
+      if (body.purpose !== 'answer') {
+        throw new Error(`Unexpected second purpose: ${String(body.purpose || '')}`);
+      }
+      if (body.sessionContext?.lastPurpose !== 'answer') {
+        throw new Error(`Missing follow-up answer purpose: ${String(body.sessionContext?.lastPurpose || '')}`);
+      }
+      if (body.sessionContext?.lastEntity !== 'moon') {
+        throw new Error(`Missing follow-up entity: ${String(body.sessionContext?.lastEntity || '')}`);
+      }
+      if (!String(body.sessionContext?.lastAnswer || '').includes("Earth's natural satellite")) {
+        throw new Error('Missing prior answer in follow-up session context');
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return {
+            mode: 'answer',
+            speech: 'It affects tides and helps stabilize Earths axial tilt.',
+            summary: '',
+            answer: 'It affects tides and helps stabilize Earths axial tilt.',
+            suggestions: [],
+            plan: { steps: [] }
+          };
+        }
+      };
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/background.js' });
+
+  await page.evaluate(() => {
+    // @ts-ignore
+    (window as any).chrome.storage.sync.get = (_defaults: any, cb: (res: any) => void) => {
+      cb({
+        navable_settings: {
+          aiEnabled: true,
+          aiMode: 'summary',
+          language: 'en-US',
+          autostart: false
+        }
+      });
+    };
+    // @ts-ignore
+    (window as any).chrome.runtime.sendMessage = async () => ({
+      ok: false,
+      error: 'I could not answer that right now.'
+    });
+  });
+
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+  await page.addScriptTag({ path: 'src/common/speech.js' });
+  await page.addScriptTag({ path: 'src/content.js' });
+
+  await page.waitForFunction(() => (window as any).NavableTools?.handleTranscript);
+
+  await page.evaluate(async () => {
+    // @ts-ignore
+    await (window as any).NavableTools.handleTranscript('What is the moon?', 'en');
+    // @ts-ignore
+    await (window as any).NavableTools.handleTranscript('tell me more', 'en');
+  });
+
+  await expect(page.locator('#navable-output-text')).toHaveValue(/stabilize Earths axial tilt/);
 });
 
 test('summary requests use the unified assistant endpoint', async ({ page }) => {


### PR DESCRIPTION
## Summary
This PR makes the Navable assistant more conversational, better at routing user intent, and able to act on browser-navigation requests instead of only speaking about them.

The main changes are:
- add short-lived assistant session memory so follow-up prompts like `tell me more` and pronoun-based questions can reuse the prior topic
- route utterances more accurately between answer, page-help, and summary flows so general questions stop carrying unnecessary page context while page-help requests keep it
- support assistant `open_site` actions end to end so spoken requests such as `open Facebook` or `خذني على فيسبوك` can open the destination instead of producing a refusal
- protect privacy by marking sensitive page snapshots and excluding sensitive page details from assistant memory
- document the new assistant request/response contract and expand automated coverage for the new behavior

## Why
Before this change, the assistant handled each turn mostly in isolation. That created a few concrete problems:
- short follow-ups like `tell me more` lost the previous entity and often triggered clarifying questions instead of a direct answer
- page-aware commands and general-knowledge questions were not separated cleanly, so content pages could send page structure even when the user was clearly asking a normal informational question
- browser-navigation requests could be interpreted as unsupported assistant questions instead of actionable navigation intents
- page snapshots already filtered sensitive fields, but the assistant memory layer did not yet have a consistent privacy-aware representation for storing continuity hints

These changes address those gaps while keeping the memory short-lived, scoped, and sanitized.

## How It Works
### 1. Session-aware assistant routing
`src/content.js`, `src/newtab/newtab.js`, and `src/background.js` now classify turns more deliberately:
- explicit page-help requests such as `help me here`, `where am I`, and multilingual equivalents stay on the page-assistant path
- direct knowledge questions stay on the answer path and avoid attaching page structure unnecessarily
- follow-up phrases such as `tell me more` inherit the previous purpose when that is the safest interpretation

### 2. Short-lived session memory
The background script now keeps assistant session state in `chrome.storage.session` with an in-memory fallback for tests. The stored context includes:
- last purpose
- last user utterance
- last entity
- last assistant reply / answer
- sanitized last-page summary hints
- lightweight domain habit metadata

This memory is intentionally scoped and time-limited:
- assistant sessions expire after 15 minutes
- domain habit hints expire after 24 hours
- tab navigation and tab removal clear or reset session state where appropriate

### 3. Backend follow-up resolution
`backend/src/server.js` now accepts `sessionContext` and uses it to resolve ambiguous follow-ups.

The backend adds helpers that:
- rewrite short follow-ups into explicit questions when a prior entity is available, for example `tell me more` -> `Tell me more about moon.`
- rewrite pronoun-based questions to the last known entity when that inference is justified
- detect clarifying model responses and retry with the resolved question when the topic was already recoverable from session memory

This reduces unnecessary back-and-forth and makes voice follow-ups sound more natural.

### 4. Assistant actions for browser navigation
The assistant contract now supports an `action` payload, starting with:
- `open_site`

That action is supported end to end:
- direct intent parsing in the extension catches polite open-site phrasing early when possible
- the backend may also return an `open_site` action for requests phrased as assistant questions
- the background executes the action by opening the resolved destination in the browser and returns an action-mode response instead of a denial

This keeps the assistant aligned with what Navable can actually do for the user.

### 5. Privacy-aware page memory
`buildPageStructure()` now reports page privacy metadata:
- `privacy.sensitiveInputCount`
- `privacy.sensitivePage`

That metadata is then used when storing assistant memory so sensitive pages do not persist labels or summaries that could expose private information.

### 6. API documentation and backend exports
The OpenAPI spec now documents:
- `sessionContext` on `AssistantRequest`
- `action` on `AssistantResponse`
- the new `action` response mode

The backend server also exports the follow-up resolution helpers to make them directly testable.

## Files of Interest
- `src/background.js`: session persistence, routing, action execution, tab lifecycle cleanup
- `src/content.js`: content-page purpose detection, local fallback memory, privacy metadata
- `src/newtab/newtab.js`: new-tab voice routing, follow-up memory, open-site parsing improvements
- `backend/src/server.js`: session-aware backend behavior, action responses, follow-up resolution
- `backend/src/openapi.js`: assistant API contract updates

## Test Coverage
Added and updated tests for:
- sender-tab plan execution for page-context assistant requests
- answer follow-ups carrying session memory
- content-side omission of page structure for general questions
- explicit page-help requests still sending page structure
- direct and assistant-returned open-site actions
- sensitive-page metadata in structure snapshots
- content and direct-fallback follow-up memory reuse
- backend helper coverage for follow-up resolution and clarifying-answer detection

## Verification
Ran successfully:
- `npx playwright test tests/background-routing.spec.ts tests/open-site.spec.ts tests/structure-and-plan.spec.ts tests/voice-qa.spec.ts tests/backend-follow-up.spec.ts`
- `npm run lint`

## Outcome
After this PR, Navable responds more like a continuous assistant instead of a stateless endpoint:
- follow-ups retain context
- page help stays page-aware
- general questions stay concise
- website-opening requests execute as actions
- assistant memory remains privacy-conscious