### PR TITLE
fix(forms): infer semantic labels for fields and grouped choices

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -7,7 +7,7 @@
   "options_page": "src/options/index.html",
   "chrome_url_overrides": { "newtab": "src/newtab/newtab.html" },
   "icons": { "16": "assets/icon16.png", "48": "assets/icon48.png", "128": "assets/icon128.png" },
-  "permissions": ["tabs", "scripting", "storage"],
+  "permissions": ["tabs", "scripting", "storage", "tts"],
   "host_permissions": ["https://*/*", "http://*/*"],
   "background": { "service_worker": "src/background.js", "type": "module" },
   "content_scripts": [

--- a/dist/src/background.js
+++ b/dist/src/background.js
@@ -139,6 +139,28 @@ if (typeof window !== 'undefined' && typeof chrome === 'undefined') {
         });
       }
     },
+    tts: {
+      _spoken: [],
+      _stopCount: 0,
+      speak(text, options, cb) {
+        chrome.tts._spoken.push({
+          text: String(text || ''),
+          options: options || {}
+        });
+        if (typeof cb === 'function') setTimeout(() => cb(), 0);
+        if (options && typeof options.onEvent === 'function') {
+          setTimeout(() => {
+            try { options.onEvent({ type: 'start' }); } catch (_err) { /* ignore */ }
+          }, 0);
+          setTimeout(() => {
+            try { options.onEvent({ type: 'end' }); } catch (_err2) { /* ignore */ }
+          }, 10);
+        }
+      },
+      stop() {
+        chrome.tts._stopCount += 1;
+      }
+    },
     storage: {
       sync: syncStorage,
       session: sessionStorage,
@@ -251,6 +273,91 @@ function configuredOutputLanguage(settings = {}, requestedOutputLanguage = '') {
   const mode = normalizeLanguageMode(settings.languageMode, settings.language || 'en-US');
   if (mode !== 'auto') return mode;
   return normalizeOutputLanguage(settings.language || 'en-US');
+}
+
+function supportsExtensionTts() {
+  return !!(chrome && chrome.tts && typeof chrome.tts.speak === 'function');
+}
+
+function stopExtensionTts() {
+  return new Promise((resolve) => {
+    if (!supportsExtensionTts()) {
+      resolve(false);
+      return;
+    }
+    try {
+      if (typeof chrome.tts.stop === 'function') chrome.tts.stop();
+      resolve(true);
+    } catch (_err) {
+      resolve(false);
+    }
+  });
+}
+
+function speakWithExtensionTts(text, opts = {}) {
+  return new Promise((resolve) => {
+    const message = String(text || '').trim();
+    if (!message || !supportsExtensionTts()) {
+      resolve({ ok: false, error: 'tts unavailable' });
+      return;
+    }
+
+    try {
+      if (typeof chrome.tts.stop === 'function') chrome.tts.stop();
+    } catch (_err) {
+      // ignore
+    }
+
+    const speakOptions = {
+      enqueue: false,
+      lang: typeof opts.lang === 'string' && opts.lang.trim() ? String(opts.lang).trim() : undefined,
+      desiredEventTypes: ['start', 'end', 'interrupted', 'cancelled', 'error']
+    };
+    let finished = false;
+    const fallbackMs = Math.min(20000, Math.max(2500, message.length * 90));
+    const fallbackTimer = setTimeout(() => {
+      if (finished) return;
+      finished = true;
+      resolve({ ok: true, eventType: 'timeout' });
+    }, fallbackMs);
+
+    function finish(result) {
+      if (finished) return;
+      finished = true;
+      try { clearTimeout(fallbackTimer); } catch (_err) { /* ignore */ }
+      resolve(result);
+    }
+
+    speakOptions.onEvent = (event) => {
+      const type = event && event.type ? String(event.type) : '';
+      if (!type) return;
+      if (type === 'error') {
+        finish({
+          ok: false,
+          error: event && event.errorMessage ? String(event.errorMessage) : 'tts error',
+          eventType: type
+        });
+        return;
+      }
+      if (type === 'end' || type === 'interrupted' || type === 'cancelled') {
+        finish({ ok: true, eventType: type });
+      }
+    };
+
+    try {
+      chrome.tts.speak(message, speakOptions, () => {
+        const lastError = chrome.runtime && chrome.runtime.lastError && chrome.runtime.lastError.message
+          ? String(chrome.runtime.lastError.message)
+          : '';
+        if (lastError) {
+          finish({ ok: false, error: lastError });
+          return;
+        }
+      });
+    } catch (err) {
+      finish({ ok: false, error: String(err || 'tts failed') });
+    }
+  });
 }
 
 function canonicalizeLocale(lang) {
@@ -1891,6 +1998,26 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       sendResponse({ ok: false, error: String(err || 'planner failed') });
     });
     return true;
+  }
+  if (msg && msg.type === 'navable:tts') {
+    if (msg.action === 'stop') {
+      stopExtensionTts().then((ok) => {
+        sendResponse({ ok: !!ok });
+      }).catch((err) => {
+        sendResponse({ ok: false, error: String(err || 'tts stop failed') });
+      });
+      return true;
+    }
+    if (msg.action === 'speak') {
+      speakWithExtensionTts(msg.text || '', {
+        lang: msg.lang || ''
+      }).then((res) => {
+        sendResponse(res);
+      }).catch((err) => {
+        sendResponse({ ok: false, error: String(err || 'tts failed') });
+      });
+      return true;
+    }
   }
   if (msg && msg.type === 'bus:request') {
     if (msg.kind === 'planner:run') {

--- a/dist/src/content.js
+++ b/dist/src/content.js
@@ -14,16 +14,35 @@
   function announce(text, opts) {
     try {
       const options = opts || { mode: 'polite' };
+      const msg = String(text || '').trim();
+      const useChromeTts = prefersChromeTtsOutput();
+      if (!msg) return;
       if (typeof window.NavableAnnounce === 'function') {
-        window.NavableAnnounce(text, options);
+        window.NavableAnnounce(msg, options);
         return;
       }
-      if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
-        window.NavableAnnounce.speak(text, options);
+      if (window.NavableAnnounce && useChromeTts && typeof window.NavableAnnounce.output === 'function') {
+        window.NavableAnnounce.output(msg, options);
+      } else if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
+        window.NavableAnnounce.speak(msg, options);
         return;
+      } else if (window.NavableAnnounce && typeof window.NavableAnnounce.output === 'function') {
+        window.NavableAnnounce.output(msg, options);
       }
-      if (window.NavableAnnounce && typeof window.NavableAnnounce.output === 'function') {
-        window.NavableAnnounce.output(text, options);
+
+      if (useChromeTts) {
+        var playbackToken = beginTtsPlayback();
+        requestChromeTtsSpeak(msg, options).then(function (spoken) {
+          finishTtsPlayback(playbackToken, spoken ? 450 : 0);
+          if (spoken) return;
+          try {
+            if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
+              window.NavableAnnounce.speak(msg, options);
+            }
+          } catch (_err) {
+            // ignore
+          }
+        });
       }
     } catch (_e) {
       // no-op
@@ -55,9 +74,74 @@
     return normalized === 'ar' || normalized === 'en' ? normalized : 'auto';
   }
 
+  function normalizeOutputMode(mode) {
+    var raw = String(mode || '').trim().toLowerCase();
+    if (raw === 'chrome_tts' || raw === 'chrome-tts' || raw === 'chrome tts') return 'chrome_tts';
+    return 'screen_reader';
+  }
+
   function configuredLanguageMode(state) {
     var source = state || settings || {};
     return normalizeLanguageMode(source.languageMode, source.language || 'en-US');
+  }
+
+  function configuredOutputMode(state) {
+    var source = state || settings || {};
+    return normalizeOutputMode(source.outputMode);
+  }
+
+  function prefersChromeTtsOutput(state) {
+    return configuredOutputMode(state) === 'chrome_tts';
+  }
+
+  function requestChromeTtsSpeak(text, opts) {
+    return new Promise(function (resolve) {
+      var message = String(text || '').trim();
+      if (!message || !(chrome && chrome.runtime && typeof chrome.runtime.sendMessage === 'function')) {
+        resolve(false);
+        return;
+      }
+      try {
+        var maybePromise = chrome.runtime.sendMessage({
+          type: 'navable:tts',
+          action: 'speak',
+          text: message,
+          lang: opts && opts.lang ? String(opts.lang) : outputLocale(currentOutputLanguage())
+        }, function (response) {
+          var lastError = chrome.runtime && chrome.runtime.lastError && chrome.runtime.lastError.message
+            ? String(chrome.runtime.lastError.message)
+            : '';
+          if (lastError) {
+            resolve(false);
+            return;
+          }
+          resolve(!!(response && response.ok));
+        });
+        if (maybePromise && typeof maybePromise.then === 'function') {
+          maybePromise.then(function (response) {
+            resolve(!!(response && response.ok));
+          }).catch(function () {
+            resolve(false);
+          });
+        }
+      } catch (_err) {
+        resolve(false);
+      }
+    });
+  }
+
+  function requestChromeTtsStop() {
+    if (!(chrome && chrome.runtime && typeof chrome.runtime.sendMessage === 'function')) return;
+    try {
+      var maybePromise = chrome.runtime.sendMessage({ type: 'navable:tts', action: 'stop' }, function () {
+        void chrome.runtime.lastError;
+      });
+      if (maybePromise && typeof maybePromise.catch === 'function') {
+        maybePromise.catch(function () {});
+      }
+    } catch (_err) {
+      // ignore
+    }
   }
 
   function lockedOutputLanguage(state) {
@@ -343,7 +427,7 @@
   var overlayMarkers = [];
   var observer; // mutation observer
   var scanDebounce;
-  var settings = { language: 'en-US', languageMode: 'auto', overlay: false, autostart: true };
+  var settings = { language: 'en-US', languageMode: 'auto', outputMode: 'screen_reader', overlay: false, autostart: true };
 
   function isHidden(el) {
     if (!el || !el.isConnected) return true;
@@ -682,6 +766,19 @@
   var HEADING_LIKE_TOKENS = ['heading', 'section', 'title', 'part'];
   var EMAIL_FIELD_TOKENS = ['email', 'e mail', 'mail'];
   var LONG_TEXT_FIELD_TOKENS = ['description', 'message', 'comment', 'comments', 'bio', 'about', 'notes', 'details', 'summary', 'experience', 'objective', 'cover letter'];
+  var GENERIC_FORM_LABEL_TEXT = {
+    input: true,
+    'unnamed input': true,
+    text: true,
+    textarea: true,
+    select: true,
+    checkbox: true,
+    radio: true,
+    option: true,
+    field: true,
+    control: true
+  };
+  var DESCRIPTIVE_PLACEHOLDER_TOKENS = ['enter', 'type', 'search', 'find', 'choose', 'select', 'pick', 'your', 'email', 'mail', 'name', 'phone', 'mobile', 'number', 'address', 'city', 'country', 'state', 'zip', 'postal', 'password', 'username', 'date', 'birth', 'message', 'comment', 'description', 'subject', 'company', 'organization', 'gender'];
   var FORM_CONFIRMATION_MAX_CORRECTIONS = 3;
   var EMAIL_SEGMENT_MAX_CORRECTIONS = 2;
   var SPELLED_VALUE_TOKEN_MAP = {
@@ -1103,12 +1200,13 @@
 
   function buildIndexedItemForElement(el, labelOverride, typeOverride) {
     if (!el || el.nodeType !== 1) return null;
-    var label = String(labelOverride || textOf(el) || '').trim();
+    var type = typeOverride || getType(el);
+    if (type === 'other') return null;
+    var inferredLabel = type === 'input' ? getFormControlLabel(el) : textOf(el);
+    var label = String(labelOverride || inferredLabel || '').trim();
     if (!label) return null;
     if (!el.dataset.navableId) el.dataset.navableId = nextId();
     el.dataset.navableLabel = label;
-    var type = typeOverride || getType(el);
-    if (type === 'other') return null;
     el.dataset.navableType = type;
     var tag = (el.tagName || '').toLowerCase();
     var item = {
@@ -1487,12 +1585,244 @@
     return el.closest ? (el.closest('form,[role="form"],dialog,[role="dialog"],main,section,article') || document.body) : document.body;
   }
 
-  function getFormControlLabel(el) {
-    var label = textOf(el);
-    if (label) return label;
+  function normalizeInlineText(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function cleanFormLabelText(value) {
+    var text = normalizeInlineText(value);
+    if (!text) return '';
+    text = text
+      .replace(/\s*\(\s*required\s*\)\s*$/i, '')
+      .replace(/\s*\*+\s*$/g, '')
+      .replace(/\s*:\s*$/g, '')
+      .trim();
+    return text;
+  }
+
+  function getWrappingLabelForControl(el) {
+    var parent = el && el.parentElement;
+    while (parent && parent !== el.ownerDocument.body) {
+      if ((parent.tagName || '').toLowerCase() === 'label') return parent;
+      parent = parent.parentElement;
+    }
+    return null;
+  }
+
+  function getAssociatedLabelElementsForControl(el) {
+    var labels = [];
+    var seen = new Set();
+
+    function pushLabel(labelEl) {
+      if (!labelEl || seen.has(labelEl)) return;
+      seen.add(labelEl);
+      labels.push(labelEl);
+    }
+
+    try {
+      if (el && el.labels && el.labels.length) {
+        Array.prototype.slice.call(el.labels).forEach(pushLabel);
+      }
+    } catch (_err) {
+      // ignore labels collection failures
+    }
+
+    pushLabel(findAssociatedLabelForControl(el));
+    pushLabel(getWrappingLabelForControl(el));
+    return labels;
+  }
+
+  function readReferencedText(el, attrName) {
+    var ids = String((el && el.getAttribute && el.getAttribute(attrName)) || '').trim();
+    if (!ids) return '';
+    var parts = ids.split(/\s+/).map(function (id) {
+      var ref = findElementByIdScoped(el, id);
+      return ref ? cleanFormLabelText(String(ref.innerText || ref.textContent || '')) : '';
+    }).filter(Boolean);
+    return cleanFormLabelText(parts.join(' '));
+  }
+
+  function elementContainsUnignoredFormControls(el, ignoredElements) {
+    if (!el || !el.querySelectorAll) return false;
+    var ignored = Array.isArray(ignoredElements) ? ignoredElements.filter(Boolean) : [];
+    var controls = el.querySelectorAll('input,select,textarea,button,[role="textbox"],[role="combobox"],[role="checkbox"],[role="radio"]');
+    outer: for (var i = 0; i < controls.length; i++) {
+      var control = controls[i];
+      for (var j = 0; j < ignored.length; j++) {
+        var ignoredEl = ignored[j];
+        if (control === ignoredEl || (ignoredEl.contains && ignoredEl.contains(control))) continue outer;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  function readStandaloneElementText(el, ignoredElements) {
+    if (!el || isHidden(el)) return '';
+    if (elementContainsUnignoredFormControls(el, ignoredElements)) return '';
+    var labelledby = readReferencedText(el, 'aria-labelledby');
+    if (labelledby) return labelledby;
     var aria = el.getAttribute && el.getAttribute('aria-label');
-    if (aria) return aria.trim();
-    return 'Unnamed input';
+    if (aria) return cleanFormLabelText(aria);
+    var title = el.getAttribute && el.getAttribute('title');
+    if (title) return cleanFormLabelText(title);
+    var text = cleanFormLabelText(String(el.innerText || el.textContent || ''));
+    if (!text || text.length > 90) return '';
+    return text;
+  }
+
+  function isLikelyExampleFormText(value) {
+    var text = normalizeInlineText(value);
+    if (!text) return false;
+    if (/\b(?:example|sample|for example|e\.?g\.?)\b/i.test(text)) return true;
+    if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(text)) return true;
+    if (/^\+?\d[\d\s()./-]{5,}$/.test(text)) return true;
+    if (/^\d{1,4}[/. -]\d{1,4}(?:[/. -]\d{1,4})?$/.test(text)) return true;
+    if (/^\d{1,2}\s+(jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\s+\d{2,4}$/i.test(text)) return true;
+    if (/^(?:dd|mm|yyyy|yy|hh|ss|month|day|year)(?:[/. -](?:dd|mm|yyyy|yy|hh|ss|month|day|year))+$/i.test(text)) return true;
+    return false;
+  }
+
+  function isDescriptivePlaceholderText(value, el) {
+    var text = cleanFormLabelText(value);
+    if (!text || isLikelyExampleFormText(text)) return false;
+    var normalized = normalizeMatchText(text);
+    if (!normalized) return false;
+    if (DESCRIPTIVE_PLACEHOLDER_TOKENS.some(function (token) { return normalized.indexOf(normalizeMatchText(token)) >= 0; })) return true;
+    var inputType = String((el && el.getAttribute && el.getAttribute('type')) || '').toLowerCase();
+    if (inputType === 'search') return true;
+    return normalized.split(' ').length <= 3 && normalized.length >= 3;
+  }
+
+  function pushFormLabelCandidate(candidates, value, score, source, opts) {
+    var text = cleanFormLabelText(value);
+    if (!text) return;
+    var normalized = normalizeMatchText(text);
+    if (!normalized || GENERIC_FORM_LABEL_TEXT[normalized]) return;
+    if (opts && opts.blocked && opts.blocked.has(normalized)) return;
+
+    var nextScore = Number(score || 0);
+    if (isLikelyExampleFormText(text)) nextScore -= 60;
+    if (source === 'placeholder' && !isDescriptivePlaceholderText(text, opts && opts.control)) return;
+    if (source === 'nearby' && text.length > 60) nextScore -= 20;
+    if (nextScore <= 0) return;
+
+    for (var i = 0; i < candidates.length; i++) {
+      if (candidates[i].normalized !== normalized) continue;
+      if (nextScore > candidates[i].score || (nextScore === candidates[i].score && text.length < candidates[i].text.length)) {
+        candidates[i] = {
+          text: text,
+          normalized: normalized,
+          score: nextScore,
+          source: source
+        };
+      }
+      return;
+    }
+
+    candidates.push({
+      text: text,
+      normalized: normalized,
+      score: nextScore,
+      source: source
+    });
+  }
+
+  function chooseBestFormLabel(candidates) {
+    if (!Array.isArray(candidates) || !candidates.length) return '';
+    candidates.sort(function (a, b) {
+      if (b.score !== a.score) return b.score - a.score;
+      if (a.text.length !== b.text.length) return a.text.length - b.text.length;
+      return a.text.localeCompare(b.text);
+    });
+    return candidates[0] ? candidates[0].text : '';
+  }
+
+  function getFormNameOrIdLabel(el) {
+    if (!el || !el.getAttribute) return '';
+    var nameText = cleanFormLabelText(humanizeIdentifier(el.getAttribute('name') || ''));
+    if (nameText) return nameText;
+    return cleanFormLabelText(humanizeIdentifier(el.id || ''));
+  }
+
+  function getSharedFormNameLabel(elements) {
+    if (!Array.isArray(elements) || !elements.length) return '';
+    var shared = '';
+    for (var i = 0; i < elements.length; i++) {
+      var next = getFormNameOrIdLabel(elements[i]);
+      if (!next) return '';
+      if (!shared) {
+        shared = next;
+        continue;
+      }
+      if (normalizeMatchText(shared) !== normalizeMatchText(next)) return '';
+    }
+    return shared;
+  }
+
+  function collectNearbyFormLabelCandidates(baseEl, opts) {
+    var candidates = [];
+    var ignored = opts && Array.isArray(opts.ignoredElements) ? opts.ignoredElements : [];
+    var boundary = (opts && opts.boundary) || getFormContainerForControl(baseEl) || document.body;
+    var current = baseEl;
+    var depth = 0;
+
+    while (current && current !== boundary && current !== document.body && depth < 5) {
+      var currentLabelledby = readReferencedText(current, 'aria-labelledby');
+      if (currentLabelledby) pushFormLabelCandidate(candidates, currentLabelledby, 96 - depth * 8, 'container_aria', opts);
+
+      var currentAria = current.getAttribute && current.getAttribute('aria-label');
+      if (currentAria) pushFormLabelCandidate(candidates, currentAria, 92 - depth * 8, 'container_aria', opts);
+
+      var sibling = current.previousElementSibling;
+      var siblingOffset = 0;
+      while (sibling && siblingOffset < 2) {
+        pushFormLabelCandidate(candidates, readStandaloneElementText(sibling, ignored), 90 - depth * 10 - siblingOffset * 6, 'nearby', opts);
+        sibling = sibling.previousElementSibling;
+        siblingOffset += 1;
+      }
+
+      current = current.parentElement;
+      depth += 1;
+    }
+
+    return candidates;
+  }
+
+  function getSharedAncestorForElements(elements) {
+    if (!Array.isArray(elements) || !elements.length) return null;
+    var current = elements[0];
+    while (current) {
+      var containsAll = elements.every(function (el) { return current.contains(el); });
+      if (containsAll) return current;
+      current = current.parentElement;
+    }
+    return elements[0].parentElement || null;
+  }
+
+  function getExplicitFormControlLabel(el, opts) {
+    var candidates = [];
+    pushFormLabelCandidate(candidates, readReferencedText(el, 'aria-labelledby'), 120, 'aria', opts);
+    pushFormLabelCandidate(candidates, el && el.getAttribute && el.getAttribute('aria-label'), 116, 'aria', opts);
+
+    getAssociatedLabelElementsForControl(el).forEach(function (labelEl, index) {
+      pushFormLabelCandidate(candidates, readStandaloneElementText(labelEl, [el]), 114 - index * 2, 'label', opts);
+    });
+
+    pushFormLabelCandidate(candidates, getLegendLabelForControl(el), 104, 'legend', opts);
+    return chooseBestFormLabel(candidates);
+  }
+
+  function getFormControlLabel(el) {
+    var candidates = [];
+    var opts = { control: el };
+    pushFormLabelCandidate(candidates, getExplicitFormControlLabel(el, opts), 120, 'explicit', opts);
+    collectNearbyFormLabelCandidates(el, opts).forEach(function (candidate) {
+      pushFormLabelCandidate(candidates, candidate.text, candidate.score, candidate.source, opts);
+    });
+    pushFormLabelCandidate(candidates, getFormNameOrIdLabel(el), 86, 'name', opts);
+    pushFormLabelCandidate(candidates, el && el.getAttribute && el.getAttribute('placeholder'), 48, 'placeholder', opts);
+    return chooseBestFormLabel(candidates) || 'Unnamed input';
   }
 
   function getLegendLabelForControl(el) {
@@ -1502,18 +1832,51 @@
     return legend ? String(textOf(legend) || '').trim() : '';
   }
 
-  function buildRadioGroupField(radios) {
+  function getRadioOptionLabel(radio, index) {
+    var candidates = [];
+    var opts = { control: radio };
+    pushFormLabelCandidate(candidates, getExplicitFormControlLabel(radio, opts), 120, 'explicit', opts);
+    pushFormLabelCandidate(candidates, radio && radio.getAttribute && radio.getAttribute('value'), 72, 'value', opts);
+    pushFormLabelCandidate(candidates, getFormNameOrIdLabel(radio), 58, 'name', opts);
+    return chooseBestFormLabel(candidates) || ('Option ' + (index + 1));
+  }
+
+  function getRadioGroupLabel(radios, options) {
     var first = radios[0];
-    var label = getLegendLabelForControl(first) || getFormControlLabel(first) || 'Choices';
+    var optionLabels = Array.isArray(options) ? options : [];
+    var blocked = new Set(optionLabels.map(function (option) {
+      return normalizeMatchText(option && option.label ? option.label : '');
+    }).filter(Boolean));
+    var sharedAncestor = getSharedAncestorForElements(radios) || first;
+    var opts = {
+      control: first,
+      blocked: blocked,
+      ignoredElements: radios,
+      boundary: getFormContainerForControl(sharedAncestor)
+    };
+    var candidates = [];
+
+    pushFormLabelCandidate(candidates, getLegendLabelForControl(first), 130, 'legend', opts);
+    pushFormLabelCandidate(candidates, readReferencedText(sharedAncestor, 'aria-labelledby'), 122, 'container_aria', opts);
+    pushFormLabelCandidate(candidates, sharedAncestor && sharedAncestor.getAttribute && sharedAncestor.getAttribute('aria-label'), 118, 'container_aria', opts);
+    collectNearbyFormLabelCandidates(sharedAncestor, opts).forEach(function (candidate) {
+      pushFormLabelCandidate(candidates, candidate.text, candidate.score, candidate.source, opts);
+    });
+    pushFormLabelCandidate(candidates, getSharedFormNameLabel(radios), 84, 'name', opts);
+    return chooseBestFormLabel(candidates) || (optionLabels[0] && optionLabels[0].label) || 'Choices';
+  }
+
+  function buildRadioGroupField(radios) {
     var required = radios.some(function (radio) { return !!(radio.hasAttribute && radio.hasAttribute('required')); });
     var options = radios.map(function (radio, index) {
-      var optionLabel = getFormControlLabel(radio) || ('Option ' + (index + 1));
+      var optionLabel = getRadioOptionLabel(radio, index);
       return {
         label: optionLabel,
         value: String((radio.getAttribute && radio.getAttribute('value')) || optionLabel),
         element: radio
       };
     });
+    var label = getRadioGroupLabel(radios, options);
     return {
       kind: 'radio',
       label: label,
@@ -3041,6 +3404,9 @@
   var voiceTurnInFlight = false;
   var voiceTurnResumeTimer = null;
   var suppressedSpeechDepth = 0;
+  var ttsPlaybackInFlight = false;
+  var ttsPlaybackToken = 0;
+  var ttsPlaybackResumeTimer = null;
 
   function clearTransientRestoreTimer() {
     if (!transientRestoreTimer) return;
@@ -3066,6 +3432,31 @@
     voiceTurnResumeTimer = null;
   }
 
+  function clearTtsPlaybackResumeTimer() {
+    if (!ttsPlaybackResumeTimer) return;
+    try { clearTimeout(ttsPlaybackResumeTimer); } catch (_err) { /* ignore */ }
+    ttsPlaybackResumeTimer = null;
+  }
+
+  function beginTtsPlayback() {
+    ttsPlaybackToken += 1;
+    clearTtsPlaybackResumeTimer();
+    ttsPlaybackInFlight = true;
+    syncListening({ announce: false });
+    return ttsPlaybackToken;
+  }
+
+  function finishTtsPlayback(token, cooldownMs) {
+    if (token !== ttsPlaybackToken) return;
+    clearTtsPlaybackResumeTimer();
+    ttsPlaybackResumeTimer = setTimeout(function () {
+      if (token !== ttsPlaybackToken) return;
+      ttsPlaybackResumeTimer = null;
+      ttsPlaybackInFlight = false;
+      syncListening({ announce: false });
+    }, Math.max(0, typeof cooldownMs === 'number' ? cooldownMs : 450));
+  }
+
   function getLiveRegion(mode) {
     var m = mode === 'assertive' ? 'assertive' : 'polite';
     return document.getElementById('navable-live-region-' + m);
@@ -3083,8 +3474,12 @@
     if (!isTransient) {
       lastSpoken = msg;
       clearTransientRestoreTimer();
-      // Rely on the ARIA live region + screen reader; do not use browser text-to-speech.
       announce(lastSpoken, { mode: mode, lang: lang });
+      return;
+    }
+
+    if (prefersChromeTtsOutput()) {
+      announce(msg, { mode: mode, lang: lang });
       return;
     }
 
@@ -3132,6 +3527,7 @@
   function computeShouldListen() {
     if (outputOpen) return false;
     if (voiceTurnInFlight) return false;
+    if (ttsPlaybackInFlight) return false;
     if (!isPageActiveForVoice()) return false;
     if (manualListening === true) return true;
     if (manualListening === false) return false;
@@ -3280,6 +3676,11 @@
     if (!recognizer) {
       if (opts.announce !== false) speak(translate('speech_not_available'));
       listening = false;
+      return;
+    }
+    if (opts.announce && prefersChromeTtsOutput()) {
+      listening = false;
+      speak(translate('listening_help'));
       return;
     }
     listening = true;
@@ -4740,7 +5141,11 @@
       return;
     }
     if (cmd.type === 'repeat') { if (lastSpoken) speak(lastSpoken); return; }
-    if (cmd.type === 'stop') { try { if (window.speechSynthesis) window.speechSynthesis.cancel(); } catch (_err) { /* cancel failed */ } return; }
+    if (cmd.type === 'stop') {
+      requestChromeTtsStop();
+      try { if (window.speechSynthesis) window.speechSynthesis.cancel(); } catch (_err) { /* cancel failed */ }
+      return;
+    }
   }
 
   async function runSummaryRequest(commandText, pageStructure) {
@@ -5018,18 +5423,22 @@
 	        var s = res && res.navable_settings ? res.navable_settings : settings;
 	        var autostart = typeof s.autostart === 'boolean' ? s.autostart : true;
 	        var nextLanguageMode = normalizeLanguageMode(s.languageMode, s.language || 'en-US');
+	        var nextOutputMode = normalizeOutputMode(s.outputMode);
 	        var nextSettings = {
 	          language: s.language || 'en-US',
 	          languageMode: nextLanguageMode,
+	          outputMode: nextOutputMode,
 	          overlay: !!s.overlay,
 	          autostart: autostart
 	        };
+	        var previousOutputMode = configuredOutputMode(settings);
 	        var nextRecogLang = configuredRecognitionLocale(nextSettings);
 	        var recogLangChanged = String(nextRecogLang).toLowerCase() !== String(recogLang || '').toLowerCase();
 	        settings = nextSettings;
 	        settingsLoaded = true;
 	        recogLang = nextRecogLang;
 	        outputLanguage = lockedOutputLanguage(settings) || normalizeOutputLanguage(settings.language || 'en-US');
+	        if (previousOutputMode !== nextOutputMode) requestChromeTtsStop();
 	        if (settings.overlay) { overlayOn = true; drawOverlay(); } else { overlayOn = false; clearOverlay(); }
 	        if (recogLangChanged) refreshRecognizer({ restart: true });
 	        else syncListening({ announce: false });
@@ -5039,18 +5448,22 @@
 	        var s2 = changes.navable_settings.newValue || settings;
 	        var autostart2 = typeof s2.autostart === 'boolean' ? s2.autostart : true;
 	        var nextLanguageMode2 = normalizeLanguageMode(s2.languageMode, s2.language || 'en-US');
+	        var nextOutputMode2 = normalizeOutputMode(s2.outputMode);
 	        var nextSettings2 = {
 	          language: s2.language || 'en-US',
 	          languageMode: nextLanguageMode2,
+	          outputMode: nextOutputMode2,
 	          overlay: !!s2.overlay,
 	          autostart: autostart2
 	        };
+	        var previousOutputMode2 = configuredOutputMode(settings);
 	        var nextRecogLang2 = configuredRecognitionLocale(nextSettings2);
 	        var recogLangChanged2 = String(nextRecogLang2).toLowerCase() !== String(recogLang || '').toLowerCase();
 	        settings = nextSettings2;
 	        settingsLoaded = true;
 	        recogLang = nextRecogLang2;
 	        outputLanguage = lockedOutputLanguage(settings) || normalizeOutputLanguage(settings.language || 'en-US');
+	        if (previousOutputMode2 !== nextOutputMode2) requestChromeTtsStop();
 	        if (settings.overlay) { overlayOn = true; drawOverlay(); } else { overlayOn = false; clearOverlay(); }
 	        if (recogLangChanged2) refreshRecognizer({ restart: true });
 	        else syncListening({ announce: false });

--- a/dist/src/newtab/newtab.js
+++ b/dist/src/newtab/newtab.js
@@ -73,10 +73,30 @@ function announce(text, mode = 'polite') {
   const msg = String(text || '').trim();
   if (!msg) return;
   try {
-    if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
-      window.NavableAnnounce.speak(msg, {
-        mode: mode === 'assertive' ? 'assertive' : 'polite',
-        lang: outputLocale(currentOutputLanguage())
+    const options = {
+      mode: mode === 'assertive' ? 'assertive' : 'polite',
+      lang: outputLocale(currentOutputLanguage())
+    };
+    if (prefersNewtabChromeTtsOutput() && window.NavableAnnounce && typeof window.NavableAnnounce.output === 'function') {
+      window.NavableAnnounce.output(msg, options);
+    } else if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
+      window.NavableAnnounce.speak(msg, options);
+    } else if (window.NavableAnnounce && typeof window.NavableAnnounce.output === 'function') {
+      window.NavableAnnounce.output(msg, options);
+    }
+
+    if (prefersNewtabChromeTtsOutput()) {
+      const playbackToken = beginNewtabTtsPlayback();
+      requestNewtabChromeTtsSpeak(msg, options).then((spoken) => {
+        finishNewtabTtsPlayback(playbackToken, spoken ? 450 : 0);
+        if (spoken) return;
+        try {
+          if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
+            window.NavableAnnounce.speak(msg, options);
+          }
+        } catch (_err2) {
+          // ignore
+        }
       });
     }
   } catch (_err) {
@@ -103,6 +123,64 @@ function normalizeLanguageMode(mode, fallbackLanguage) {
   if (!String(mode || '').trim()) return 'auto';
   const normalized = normalizeOutputLanguage(mode || fallbackLanguage || 'en-US');
   return normalized === 'ar' || normalized === 'en' ? normalized : 'auto';
+}
+
+function normalizeOutputMode(mode) {
+  const raw = String(mode || '').trim().toLowerCase();
+  if (raw === 'chrome_tts' || raw === 'chrome-tts' || raw === 'chrome tts') return 'chrome_tts';
+  return 'screen_reader';
+}
+
+function prefersNewtabChromeTtsOutput() {
+  return normalizeOutputMode(newtabOutputMode) === 'chrome_tts';
+}
+
+function requestNewtabChromeTtsSpeak(text, opts = {}) {
+  return new Promise((resolve) => {
+    const msg = String(text || '').trim();
+    if (!msg || !chrome?.runtime?.sendMessage) {
+      resolve(false);
+      return;
+    }
+    try {
+      const maybePromise = chrome.runtime.sendMessage({
+        type: 'navable:tts',
+        action: 'speak',
+        text: msg,
+        lang: opts.lang || outputLocale(currentOutputLanguage())
+      }, (response) => {
+        const lastError = chrome?.runtime?.lastError?.message ? String(chrome.runtime.lastError.message) : '';
+        if (lastError) {
+          resolve(false);
+          return;
+        }
+        resolve(!!(response && response.ok));
+      });
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        maybePromise.then((response) => {
+          resolve(!!(response && response.ok));
+        }).catch(() => {
+          resolve(false);
+        });
+      }
+    } catch (_err) {
+      resolve(false);
+    }
+  });
+}
+
+function requestNewtabChromeTtsStop() {
+  if (!chrome?.runtime?.sendMessage) return;
+  try {
+    const maybePromise = chrome.runtime.sendMessage({ type: 'navable:tts', action: 'stop' }, () => {
+      void chrome?.runtime?.lastError;
+    });
+    if (maybePromise && typeof maybePromise.catch === 'function') {
+      maybePromise.catch(() => {});
+    }
+  } catch (_err) {
+    // ignore
+  }
 }
 
 function currentLanguageMode() {
@@ -423,6 +501,7 @@ let newtabVoiceReady = false;
 let newtabVoiceLang = 'en-US';
 let newtabConfiguredVoiceLang = 'en-US';
 let newtabLanguageMode = 'auto';
+let newtabOutputMode = 'screen_reader';
 let newtabOutputLanguage = 'en';
 let newtabRecognizerRefreshTimer = null;
 let newtabLastRecognitionResultAt = 0;
@@ -430,6 +509,9 @@ let newtabLastRecognitionLocaleRotateAt = 0;
 let newtabVoiceTurnInFlight = false;
 let newtabVoiceTurnResumeTimer = null;
 let newtabPausedForVisibility = false;
+let newtabTtsPlaybackInFlight = false;
+let newtabTtsPlaybackToken = 0;
+let newtabTtsPlaybackResumeTimer = null;
 
 function clearNewtabRecognizerRefreshTimer() {
   if (!newtabRecognizerRefreshTimer) return;
@@ -451,6 +533,49 @@ function clearNewtabVoiceTurnResumeTimer() {
   newtabVoiceTurnResumeTimer = null;
 }
 
+function clearNewtabTtsPlaybackResumeTimer() {
+  if (!newtabTtsPlaybackResumeTimer) return;
+  try {
+    clearTimeout(newtabTtsPlaybackResumeTimer);
+  } catch (_err) {
+    // ignore
+  }
+  newtabTtsPlaybackResumeTimer = null;
+}
+
+function beginNewtabTtsPlayback() {
+  newtabTtsPlaybackToken += 1;
+  clearNewtabTtsPlaybackResumeTimer();
+  newtabTtsPlaybackInFlight = true;
+  const oldRecognizer = newtabRecognizer;
+  newtabRecognizer = null;
+  try {
+    oldRecognizer && oldRecognizer.stop();
+  } catch (_err) {
+    // ignore
+  }
+  refreshNewtabMicUi();
+  return newtabTtsPlaybackToken;
+}
+
+function finishNewtabTtsPlayback(token, cooldownMs = 450) {
+  if (token !== newtabTtsPlaybackToken) return;
+  clearNewtabTtsPlaybackResumeTimer();
+  newtabTtsPlaybackResumeTimer = setTimeout(() => {
+    if (token !== newtabTtsPlaybackToken) return;
+    newtabTtsPlaybackResumeTimer = null;
+    newtabTtsPlaybackInFlight = false;
+    refreshNewtabMicUi();
+    if (newtabVoiceTurnInFlight || !shouldNewtabListen()) return;
+    ensureNewtabRecognizer()
+      .then((recognizer) => {
+        if (!recognizer || newtabVoiceTurnInFlight || !shouldNewtabListen()) return;
+        recognizer.start();
+      })
+      .catch(() => {});
+  }, Math.max(0, cooldownMs));
+}
+
 function isNewtabVisibleForVoice() {
   try {
     return !document.visibilityState || document.visibilityState === 'visible';
@@ -460,7 +585,13 @@ function isNewtabVisibleForVoice() {
 }
 
 function shouldNewtabListen() {
-  return !!(newtabWantsListening && !newtabVoiceTurnInFlight && !newtabPausedForVisibility && isNewtabVisibleForVoice());
+  return !!(
+    newtabWantsListening &&
+    !newtabVoiceTurnInFlight &&
+    !newtabPausedForVisibility &&
+    !newtabTtsPlaybackInFlight &&
+    isNewtabVisibleForVoice()
+  );
 }
 
 function maybeRotateNewtabRecognitionLocale() {
@@ -514,6 +645,11 @@ function refreshNewtabMicUi() {
     status.textContent = translate('processing_request');
     return;
   }
+  if (newtabTtsPlaybackInFlight) {
+    btn.textContent = 'Speaking…';
+    status.textContent = 'Playing Navable reply…';
+    return;
+  }
   if (newtabPausedForVisibility) {
     btn.textContent = 'Listening paused';
     status.textContent = translate('listening_paused_hidden');
@@ -533,16 +669,17 @@ function setNewtabMicMessage(text, mode = 'polite') {
 async function loadNewtabVoiceSettings() {
   return new Promise((resolve) => {
     try {
-      if (!chrome?.storage?.sync?.get) return resolve({ language: 'en-US', languageMode: 'auto' });
+      if (!chrome?.storage?.sync?.get) return resolve({ language: 'en-US', languageMode: 'auto', outputMode: 'screen_reader' });
       chrome.storage.sync.get({ navable_settings: {} }, (res) => {
         const s = (res && res.navable_settings) || {};
         resolve({
           language: s.language || 'en-US',
-          languageMode: normalizeLanguageMode(s.languageMode, s.language || 'en-US')
+          languageMode: normalizeLanguageMode(s.languageMode, s.language || 'en-US'),
+          outputMode: normalizeOutputMode(s.outputMode)
         });
       });
     } catch (_err) {
-      resolve({ language: 'en-US', languageMode: 'auto' });
+      resolve({ language: 'en-US', languageMode: 'auto', outputMode: 'screen_reader' });
     }
   });
 }
@@ -551,6 +688,7 @@ async function ensureNewtabRecognizer() {
   const settings = await loadNewtabVoiceSettings();
   const previousConfiguredVoiceLang = newtabConfiguredVoiceLang;
   const previousConfiguredOutputLanguage = lockedOutputLanguage() || normalizeOutputLanguage(previousConfiguredVoiceLang || 'en-US');
+  newtabOutputMode = normalizeOutputMode(settings.outputMode);
   newtabLanguageMode = normalizeLanguageMode(settings.languageMode, settings.language || 'en-US');
   newtabConfiguredVoiceLang = (() => {
     const configured = newtabRecognitionLocaleFor(settings.language || 'en-US');
@@ -910,6 +1048,11 @@ async function startNewtabListening() {
 
   if (!shouldNewtabListen()) return;
 
+  if (prefersNewtabChromeTtsOutput()) {
+    setNewtabMicMessage(translate('newtab_listening'), 'polite');
+    return;
+  }
+
   const recognizer = await ensureNewtabRecognizer();
   if (!recognizer) {
     newtabWantsListening = false;
@@ -950,6 +1093,9 @@ async function toggleNewtabListening() {
 
 function wireNewtabVoice() {
   newtabVoiceReady = true;
+  loadNewtabVoiceSettings().then((settings) => {
+    newtabOutputMode = normalizeOutputMode(settings.outputMode);
+  }).catch(() => {});
   refreshNewtabMicUi();
 
   const { btn } = getVoiceStatusEls();
@@ -987,10 +1133,21 @@ function wireNewtabVoice() {
   window.addEventListener(
     'pagehide',
     () => {
+      requestNewtabChromeTtsStop();
       if (newtabWantsListening) stopNewtabListening({ announce: false });
     },
     { capture: true }
   );
+
+  if (chrome?.storage?.onChanged?.addListener) {
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area !== 'sync' || !changes.navable_settings) return;
+      const nextSettings = changes.navable_settings.newValue || {};
+      const nextOutputMode = normalizeOutputMode(nextSettings.outputMode);
+      if (nextOutputMode !== newtabOutputMode) requestNewtabChromeTtsStop();
+      newtabOutputMode = nextOutputMode;
+    });
+  }
 
   if (!isVoiceSupported()) {
     const { btn: btn2 } = getVoiceStatusEls();

--- a/dist/src/options/index.html
+++ b/dist/src/options/index.html
@@ -61,6 +61,20 @@
             <div class="nv-options-stack">
               <div class="nv-setting-row">
                 <div class="nv-setting-copy">
+                  <h3>Reply audio</h3>
+                  <p>Choose whether Navable replies use the screen reader path or Chrome TTS. This only affects Navable output.</p>
+                </div>
+                <div class="nv-setting-control">
+                  <label class="nv-label" for="outputMode">Output mode</label>
+                  <select id="outputMode" class="nv-select">
+                    <option value="screen_reader">Screen reader</option>
+                    <option value="chrome_tts">Chrome TTS</option>
+                  </select>
+                </div>
+              </div>
+
+              <div class="nv-setting-row">
+                <div class="nv-setting-copy">
                   <h3>Conversation language</h3>
                   <p>Auto follows the user’s Arabic or English speech. Lock the mode when you want one consistent reply voice.</p>
                 </div>

--- a/dist/src/options/options.js
+++ b/dist/src/options/options.js
@@ -9,6 +9,12 @@ function normalizeLanguageMode(mode, _locale) {
   return 'auto';
 }
 
+function normalizeOutputMode(mode) {
+  const raw = String(mode || '').trim().toLowerCase();
+  if (raw === 'chrome_tts' || raw === 'chrome-tts' || raw === 'chrome tts') return 'chrome_tts';
+  return 'screen_reader';
+}
+
 function localeForLanguageMode(mode, locale) {
   const normalized = normalizeLanguageMode(mode, locale);
   const current = String(locale || '').trim();
@@ -22,6 +28,7 @@ function loadSettings() {
   chrome.storage.sync.get({ navable_settings: {} }, (res) => {
     const s = res.navable_settings || {};
     const languageMode = document.getElementById('languageMode');
+    const outputMode = document.getElementById('outputMode');
     const continuous = document.getElementById('continuous');
     const aiEnabled = document.getElementById('aiEnabled');
     const aiMode = document.getElementById('aiMode');
@@ -30,6 +37,7 @@ function loadSettings() {
 
     currentLanguageLocale = s.language || 'en-US';
     if (languageMode) languageMode.value = normalizeLanguageMode(s.languageMode, currentLanguageLocale);
+    if (outputMode) outputMode.value = normalizeOutputMode(s.outputMode);
     if (continuous) continuous.checked = typeof s.autostart === 'boolean' ? s.autostart : true;
     if (aiEnabled) aiEnabled.checked = !!s.aiEnabled;
     if (aiMode) aiMode.value = s.aiMode || 'off';
@@ -41,6 +49,7 @@ function loadSettings() {
 function saveSettings() {
   if (!chrome || !chrome.storage || !chrome.storage.sync) return;
   const languageMode = document.getElementById('languageMode');
+  const outputMode = document.getElementById('outputMode');
   const continuous = document.getElementById('continuous');
   const aiEnabled = document.getElementById('aiEnabled');
   const aiMode = document.getElementById('aiMode');
@@ -52,6 +61,7 @@ function saveSettings() {
   const navable_settings = {
     language: currentLanguageLocale,
     languageMode: normalizedLanguageMode,
+    outputMode: normalizeOutputMode(outputMode ? outputMode.value : 'screen_reader'),
     overlay: false,
     autostart: continuous ? continuous.checked : true,
     aiEnabled: aiEnabled ? aiEnabled.checked : false,
@@ -73,6 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (
       e.target &&
       (e.target.id === 'languageMode' ||
+        e.target.id === 'outputMode' ||
         e.target.id === 'continuous' ||
         e.target.id === 'aiEnabled' ||
         e.target.id === 'aiMode' ||

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "options_page": "src/options/index.html",
   "chrome_url_overrides": { "newtab": "src/newtab/newtab.html" },
   "icons": { "16": "assets/icon16.png", "48": "assets/icon48.png", "128": "assets/icon128.png" },
-  "permissions": ["tabs", "scripting", "storage"],
+  "permissions": ["tabs", "scripting", "storage", "tts"],
   "host_permissions": ["https://*/*", "http://*/*"],
   "background": { "service_worker": "src/background.js", "type": "module" },
   "content_scripts": [

--- a/src/background.js
+++ b/src/background.js
@@ -139,6 +139,28 @@ if (typeof window !== 'undefined' && typeof chrome === 'undefined') {
         });
       }
     },
+    tts: {
+      _spoken: [],
+      _stopCount: 0,
+      speak(text, options, cb) {
+        chrome.tts._spoken.push({
+          text: String(text || ''),
+          options: options || {}
+        });
+        if (typeof cb === 'function') setTimeout(() => cb(), 0);
+        if (options && typeof options.onEvent === 'function') {
+          setTimeout(() => {
+            try { options.onEvent({ type: 'start' }); } catch (_err) { /* ignore */ }
+          }, 0);
+          setTimeout(() => {
+            try { options.onEvent({ type: 'end' }); } catch (_err2) { /* ignore */ }
+          }, 10);
+        }
+      },
+      stop() {
+        chrome.tts._stopCount += 1;
+      }
+    },
     storage: {
       sync: syncStorage,
       session: sessionStorage,
@@ -251,6 +273,91 @@ function configuredOutputLanguage(settings = {}, requestedOutputLanguage = '') {
   const mode = normalizeLanguageMode(settings.languageMode, settings.language || 'en-US');
   if (mode !== 'auto') return mode;
   return normalizeOutputLanguage(settings.language || 'en-US');
+}
+
+function supportsExtensionTts() {
+  return !!(chrome && chrome.tts && typeof chrome.tts.speak === 'function');
+}
+
+function stopExtensionTts() {
+  return new Promise((resolve) => {
+    if (!supportsExtensionTts()) {
+      resolve(false);
+      return;
+    }
+    try {
+      if (typeof chrome.tts.stop === 'function') chrome.tts.stop();
+      resolve(true);
+    } catch (_err) {
+      resolve(false);
+    }
+  });
+}
+
+function speakWithExtensionTts(text, opts = {}) {
+  return new Promise((resolve) => {
+    const message = String(text || '').trim();
+    if (!message || !supportsExtensionTts()) {
+      resolve({ ok: false, error: 'tts unavailable' });
+      return;
+    }
+
+    try {
+      if (typeof chrome.tts.stop === 'function') chrome.tts.stop();
+    } catch (_err) {
+      // ignore
+    }
+
+    const speakOptions = {
+      enqueue: false,
+      lang: typeof opts.lang === 'string' && opts.lang.trim() ? String(opts.lang).trim() : undefined,
+      desiredEventTypes: ['start', 'end', 'interrupted', 'cancelled', 'error']
+    };
+    let finished = false;
+    const fallbackMs = Math.min(20000, Math.max(2500, message.length * 90));
+    const fallbackTimer = setTimeout(() => {
+      if (finished) return;
+      finished = true;
+      resolve({ ok: true, eventType: 'timeout' });
+    }, fallbackMs);
+
+    function finish(result) {
+      if (finished) return;
+      finished = true;
+      try { clearTimeout(fallbackTimer); } catch (_err) { /* ignore */ }
+      resolve(result);
+    }
+
+    speakOptions.onEvent = (event) => {
+      const type = event && event.type ? String(event.type) : '';
+      if (!type) return;
+      if (type === 'error') {
+        finish({
+          ok: false,
+          error: event && event.errorMessage ? String(event.errorMessage) : 'tts error',
+          eventType: type
+        });
+        return;
+      }
+      if (type === 'end' || type === 'interrupted' || type === 'cancelled') {
+        finish({ ok: true, eventType: type });
+      }
+    };
+
+    try {
+      chrome.tts.speak(message, speakOptions, () => {
+        const lastError = chrome.runtime && chrome.runtime.lastError && chrome.runtime.lastError.message
+          ? String(chrome.runtime.lastError.message)
+          : '';
+        if (lastError) {
+          finish({ ok: false, error: lastError });
+          return;
+        }
+      });
+    } catch (err) {
+      finish({ ok: false, error: String(err || 'tts failed') });
+    }
+  });
 }
 
 function canonicalizeLocale(lang) {
@@ -1891,6 +1998,26 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       sendResponse({ ok: false, error: String(err || 'planner failed') });
     });
     return true;
+  }
+  if (msg && msg.type === 'navable:tts') {
+    if (msg.action === 'stop') {
+      stopExtensionTts().then((ok) => {
+        sendResponse({ ok: !!ok });
+      }).catch((err) => {
+        sendResponse({ ok: false, error: String(err || 'tts stop failed') });
+      });
+      return true;
+    }
+    if (msg.action === 'speak') {
+      speakWithExtensionTts(msg.text || '', {
+        lang: msg.lang || ''
+      }).then((res) => {
+        sendResponse(res);
+      }).catch((err) => {
+        sendResponse({ ok: false, error: String(err || 'tts failed') });
+      });
+      return true;
+    }
   }
   if (msg && msg.type === 'bus:request') {
     if (msg.kind === 'planner:run') {

--- a/src/content.js
+++ b/src/content.js
@@ -14,16 +14,35 @@
   function announce(text, opts) {
     try {
       const options = opts || { mode: 'polite' };
+      const msg = String(text || '').trim();
+      const useChromeTts = prefersChromeTtsOutput();
+      if (!msg) return;
       if (typeof window.NavableAnnounce === 'function') {
-        window.NavableAnnounce(text, options);
+        window.NavableAnnounce(msg, options);
         return;
       }
-      if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
-        window.NavableAnnounce.speak(text, options);
+      if (window.NavableAnnounce && useChromeTts && typeof window.NavableAnnounce.output === 'function') {
+        window.NavableAnnounce.output(msg, options);
+      } else if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
+        window.NavableAnnounce.speak(msg, options);
         return;
+      } else if (window.NavableAnnounce && typeof window.NavableAnnounce.output === 'function') {
+        window.NavableAnnounce.output(msg, options);
       }
-      if (window.NavableAnnounce && typeof window.NavableAnnounce.output === 'function') {
-        window.NavableAnnounce.output(text, options);
+
+      if (useChromeTts) {
+        var playbackToken = beginTtsPlayback();
+        requestChromeTtsSpeak(msg, options).then(function (spoken) {
+          finishTtsPlayback(playbackToken, spoken ? 450 : 0);
+          if (spoken) return;
+          try {
+            if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
+              window.NavableAnnounce.speak(msg, options);
+            }
+          } catch (_err) {
+            // ignore
+          }
+        });
       }
     } catch (_e) {
       // no-op
@@ -55,9 +74,74 @@
     return normalized === 'ar' || normalized === 'en' ? normalized : 'auto';
   }
 
+  function normalizeOutputMode(mode) {
+    var raw = String(mode || '').trim().toLowerCase();
+    if (raw === 'chrome_tts' || raw === 'chrome-tts' || raw === 'chrome tts') return 'chrome_tts';
+    return 'screen_reader';
+  }
+
   function configuredLanguageMode(state) {
     var source = state || settings || {};
     return normalizeLanguageMode(source.languageMode, source.language || 'en-US');
+  }
+
+  function configuredOutputMode(state) {
+    var source = state || settings || {};
+    return normalizeOutputMode(source.outputMode);
+  }
+
+  function prefersChromeTtsOutput(state) {
+    return configuredOutputMode(state) === 'chrome_tts';
+  }
+
+  function requestChromeTtsSpeak(text, opts) {
+    return new Promise(function (resolve) {
+      var message = String(text || '').trim();
+      if (!message || !(chrome && chrome.runtime && typeof chrome.runtime.sendMessage === 'function')) {
+        resolve(false);
+        return;
+      }
+      try {
+        var maybePromise = chrome.runtime.sendMessage({
+          type: 'navable:tts',
+          action: 'speak',
+          text: message,
+          lang: opts && opts.lang ? String(opts.lang) : outputLocale(currentOutputLanguage())
+        }, function (response) {
+          var lastError = chrome.runtime && chrome.runtime.lastError && chrome.runtime.lastError.message
+            ? String(chrome.runtime.lastError.message)
+            : '';
+          if (lastError) {
+            resolve(false);
+            return;
+          }
+          resolve(!!(response && response.ok));
+        });
+        if (maybePromise && typeof maybePromise.then === 'function') {
+          maybePromise.then(function (response) {
+            resolve(!!(response && response.ok));
+          }).catch(function () {
+            resolve(false);
+          });
+        }
+      } catch (_err) {
+        resolve(false);
+      }
+    });
+  }
+
+  function requestChromeTtsStop() {
+    if (!(chrome && chrome.runtime && typeof chrome.runtime.sendMessage === 'function')) return;
+    try {
+      var maybePromise = chrome.runtime.sendMessage({ type: 'navable:tts', action: 'stop' }, function () {
+        void chrome.runtime.lastError;
+      });
+      if (maybePromise && typeof maybePromise.catch === 'function') {
+        maybePromise.catch(function () {});
+      }
+    } catch (_err) {
+      // ignore
+    }
   }
 
   function lockedOutputLanguage(state) {
@@ -343,7 +427,7 @@
   var overlayMarkers = [];
   var observer; // mutation observer
   var scanDebounce;
-  var settings = { language: 'en-US', languageMode: 'auto', overlay: false, autostart: true };
+  var settings = { language: 'en-US', languageMode: 'auto', outputMode: 'screen_reader', overlay: false, autostart: true };
 
   function isHidden(el) {
     if (!el || !el.isConnected) return true;
@@ -682,6 +766,19 @@
   var HEADING_LIKE_TOKENS = ['heading', 'section', 'title', 'part'];
   var EMAIL_FIELD_TOKENS = ['email', 'e mail', 'mail'];
   var LONG_TEXT_FIELD_TOKENS = ['description', 'message', 'comment', 'comments', 'bio', 'about', 'notes', 'details', 'summary', 'experience', 'objective', 'cover letter'];
+  var GENERIC_FORM_LABEL_TEXT = {
+    input: true,
+    'unnamed input': true,
+    text: true,
+    textarea: true,
+    select: true,
+    checkbox: true,
+    radio: true,
+    option: true,
+    field: true,
+    control: true
+  };
+  var DESCRIPTIVE_PLACEHOLDER_TOKENS = ['enter', 'type', 'search', 'find', 'choose', 'select', 'pick', 'your', 'email', 'mail', 'name', 'phone', 'mobile', 'number', 'address', 'city', 'country', 'state', 'zip', 'postal', 'password', 'username', 'date', 'birth', 'message', 'comment', 'description', 'subject', 'company', 'organization', 'gender'];
   var FORM_CONFIRMATION_MAX_CORRECTIONS = 3;
   var EMAIL_SEGMENT_MAX_CORRECTIONS = 2;
   var SPELLED_VALUE_TOKEN_MAP = {
@@ -1103,12 +1200,13 @@
 
   function buildIndexedItemForElement(el, labelOverride, typeOverride) {
     if (!el || el.nodeType !== 1) return null;
-    var label = String(labelOverride || textOf(el) || '').trim();
+    var type = typeOverride || getType(el);
+    if (type === 'other') return null;
+    var inferredLabel = type === 'input' ? getFormControlLabel(el) : textOf(el);
+    var label = String(labelOverride || inferredLabel || '').trim();
     if (!label) return null;
     if (!el.dataset.navableId) el.dataset.navableId = nextId();
     el.dataset.navableLabel = label;
-    var type = typeOverride || getType(el);
-    if (type === 'other') return null;
     el.dataset.navableType = type;
     var tag = (el.tagName || '').toLowerCase();
     var item = {
@@ -1487,12 +1585,244 @@
     return el.closest ? (el.closest('form,[role="form"],dialog,[role="dialog"],main,section,article') || document.body) : document.body;
   }
 
-  function getFormControlLabel(el) {
-    var label = textOf(el);
-    if (label) return label;
+  function normalizeInlineText(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function cleanFormLabelText(value) {
+    var text = normalizeInlineText(value);
+    if (!text) return '';
+    text = text
+      .replace(/\s*\(\s*required\s*\)\s*$/i, '')
+      .replace(/\s*\*+\s*$/g, '')
+      .replace(/\s*:\s*$/g, '')
+      .trim();
+    return text;
+  }
+
+  function getWrappingLabelForControl(el) {
+    var parent = el && el.parentElement;
+    while (parent && parent !== el.ownerDocument.body) {
+      if ((parent.tagName || '').toLowerCase() === 'label') return parent;
+      parent = parent.parentElement;
+    }
+    return null;
+  }
+
+  function getAssociatedLabelElementsForControl(el) {
+    var labels = [];
+    var seen = new Set();
+
+    function pushLabel(labelEl) {
+      if (!labelEl || seen.has(labelEl)) return;
+      seen.add(labelEl);
+      labels.push(labelEl);
+    }
+
+    try {
+      if (el && el.labels && el.labels.length) {
+        Array.prototype.slice.call(el.labels).forEach(pushLabel);
+      }
+    } catch (_err) {
+      // ignore labels collection failures
+    }
+
+    pushLabel(findAssociatedLabelForControl(el));
+    pushLabel(getWrappingLabelForControl(el));
+    return labels;
+  }
+
+  function readReferencedText(el, attrName) {
+    var ids = String((el && el.getAttribute && el.getAttribute(attrName)) || '').trim();
+    if (!ids) return '';
+    var parts = ids.split(/\s+/).map(function (id) {
+      var ref = findElementByIdScoped(el, id);
+      return ref ? cleanFormLabelText(String(ref.innerText || ref.textContent || '')) : '';
+    }).filter(Boolean);
+    return cleanFormLabelText(parts.join(' '));
+  }
+
+  function elementContainsUnignoredFormControls(el, ignoredElements) {
+    if (!el || !el.querySelectorAll) return false;
+    var ignored = Array.isArray(ignoredElements) ? ignoredElements.filter(Boolean) : [];
+    var controls = el.querySelectorAll('input,select,textarea,button,[role="textbox"],[role="combobox"],[role="checkbox"],[role="radio"]');
+    outer: for (var i = 0; i < controls.length; i++) {
+      var control = controls[i];
+      for (var j = 0; j < ignored.length; j++) {
+        var ignoredEl = ignored[j];
+        if (control === ignoredEl || (ignoredEl.contains && ignoredEl.contains(control))) continue outer;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  function readStandaloneElementText(el, ignoredElements) {
+    if (!el || isHidden(el)) return '';
+    if (elementContainsUnignoredFormControls(el, ignoredElements)) return '';
+    var labelledby = readReferencedText(el, 'aria-labelledby');
+    if (labelledby) return labelledby;
     var aria = el.getAttribute && el.getAttribute('aria-label');
-    if (aria) return aria.trim();
-    return 'Unnamed input';
+    if (aria) return cleanFormLabelText(aria);
+    var title = el.getAttribute && el.getAttribute('title');
+    if (title) return cleanFormLabelText(title);
+    var text = cleanFormLabelText(String(el.innerText || el.textContent || ''));
+    if (!text || text.length > 90) return '';
+    return text;
+  }
+
+  function isLikelyExampleFormText(value) {
+    var text = normalizeInlineText(value);
+    if (!text) return false;
+    if (/\b(?:example|sample|for example|e\.?g\.?)\b/i.test(text)) return true;
+    if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(text)) return true;
+    if (/^\+?\d[\d\s()./-]{5,}$/.test(text)) return true;
+    if (/^\d{1,4}[/. -]\d{1,4}(?:[/. -]\d{1,4})?$/.test(text)) return true;
+    if (/^\d{1,2}\s+(jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\s+\d{2,4}$/i.test(text)) return true;
+    if (/^(?:dd|mm|yyyy|yy|hh|ss|month|day|year)(?:[/. -](?:dd|mm|yyyy|yy|hh|ss|month|day|year))+$/i.test(text)) return true;
+    return false;
+  }
+
+  function isDescriptivePlaceholderText(value, el) {
+    var text = cleanFormLabelText(value);
+    if (!text || isLikelyExampleFormText(text)) return false;
+    var normalized = normalizeMatchText(text);
+    if (!normalized) return false;
+    if (DESCRIPTIVE_PLACEHOLDER_TOKENS.some(function (token) { return normalized.indexOf(normalizeMatchText(token)) >= 0; })) return true;
+    var inputType = String((el && el.getAttribute && el.getAttribute('type')) || '').toLowerCase();
+    if (inputType === 'search') return true;
+    return normalized.split(' ').length <= 3 && normalized.length >= 3;
+  }
+
+  function pushFormLabelCandidate(candidates, value, score, source, opts) {
+    var text = cleanFormLabelText(value);
+    if (!text) return;
+    var normalized = normalizeMatchText(text);
+    if (!normalized || GENERIC_FORM_LABEL_TEXT[normalized]) return;
+    if (opts && opts.blocked && opts.blocked.has(normalized)) return;
+
+    var nextScore = Number(score || 0);
+    if (isLikelyExampleFormText(text)) nextScore -= 60;
+    if (source === 'placeholder' && !isDescriptivePlaceholderText(text, opts && opts.control)) return;
+    if (source === 'nearby' && text.length > 60) nextScore -= 20;
+    if (nextScore <= 0) return;
+
+    for (var i = 0; i < candidates.length; i++) {
+      if (candidates[i].normalized !== normalized) continue;
+      if (nextScore > candidates[i].score || (nextScore === candidates[i].score && text.length < candidates[i].text.length)) {
+        candidates[i] = {
+          text: text,
+          normalized: normalized,
+          score: nextScore,
+          source: source
+        };
+      }
+      return;
+    }
+
+    candidates.push({
+      text: text,
+      normalized: normalized,
+      score: nextScore,
+      source: source
+    });
+  }
+
+  function chooseBestFormLabel(candidates) {
+    if (!Array.isArray(candidates) || !candidates.length) return '';
+    candidates.sort(function (a, b) {
+      if (b.score !== a.score) return b.score - a.score;
+      if (a.text.length !== b.text.length) return a.text.length - b.text.length;
+      return a.text.localeCompare(b.text);
+    });
+    return candidates[0] ? candidates[0].text : '';
+  }
+
+  function getFormNameOrIdLabel(el) {
+    if (!el || !el.getAttribute) return '';
+    var nameText = cleanFormLabelText(humanizeIdentifier(el.getAttribute('name') || ''));
+    if (nameText) return nameText;
+    return cleanFormLabelText(humanizeIdentifier(el.id || ''));
+  }
+
+  function getSharedFormNameLabel(elements) {
+    if (!Array.isArray(elements) || !elements.length) return '';
+    var shared = '';
+    for (var i = 0; i < elements.length; i++) {
+      var next = getFormNameOrIdLabel(elements[i]);
+      if (!next) return '';
+      if (!shared) {
+        shared = next;
+        continue;
+      }
+      if (normalizeMatchText(shared) !== normalizeMatchText(next)) return '';
+    }
+    return shared;
+  }
+
+  function collectNearbyFormLabelCandidates(baseEl, opts) {
+    var candidates = [];
+    var ignored = opts && Array.isArray(opts.ignoredElements) ? opts.ignoredElements : [];
+    var boundary = (opts && opts.boundary) || getFormContainerForControl(baseEl) || document.body;
+    var current = baseEl;
+    var depth = 0;
+
+    while (current && current !== boundary && current !== document.body && depth < 5) {
+      var currentLabelledby = readReferencedText(current, 'aria-labelledby');
+      if (currentLabelledby) pushFormLabelCandidate(candidates, currentLabelledby, 96 - depth * 8, 'container_aria', opts);
+
+      var currentAria = current.getAttribute && current.getAttribute('aria-label');
+      if (currentAria) pushFormLabelCandidate(candidates, currentAria, 92 - depth * 8, 'container_aria', opts);
+
+      var sibling = current.previousElementSibling;
+      var siblingOffset = 0;
+      while (sibling && siblingOffset < 2) {
+        pushFormLabelCandidate(candidates, readStandaloneElementText(sibling, ignored), 90 - depth * 10 - siblingOffset * 6, 'nearby', opts);
+        sibling = sibling.previousElementSibling;
+        siblingOffset += 1;
+      }
+
+      current = current.parentElement;
+      depth += 1;
+    }
+
+    return candidates;
+  }
+
+  function getSharedAncestorForElements(elements) {
+    if (!Array.isArray(elements) || !elements.length) return null;
+    var current = elements[0];
+    while (current) {
+      var containsAll = elements.every(function (el) { return current.contains(el); });
+      if (containsAll) return current;
+      current = current.parentElement;
+    }
+    return elements[0].parentElement || null;
+  }
+
+  function getExplicitFormControlLabel(el, opts) {
+    var candidates = [];
+    pushFormLabelCandidate(candidates, readReferencedText(el, 'aria-labelledby'), 120, 'aria', opts);
+    pushFormLabelCandidate(candidates, el && el.getAttribute && el.getAttribute('aria-label'), 116, 'aria', opts);
+
+    getAssociatedLabelElementsForControl(el).forEach(function (labelEl, index) {
+      pushFormLabelCandidate(candidates, readStandaloneElementText(labelEl, [el]), 114 - index * 2, 'label', opts);
+    });
+
+    pushFormLabelCandidate(candidates, getLegendLabelForControl(el), 104, 'legend', opts);
+    return chooseBestFormLabel(candidates);
+  }
+
+  function getFormControlLabel(el) {
+    var candidates = [];
+    var opts = { control: el };
+    pushFormLabelCandidate(candidates, getExplicitFormControlLabel(el, opts), 120, 'explicit', opts);
+    collectNearbyFormLabelCandidates(el, opts).forEach(function (candidate) {
+      pushFormLabelCandidate(candidates, candidate.text, candidate.score, candidate.source, opts);
+    });
+    pushFormLabelCandidate(candidates, getFormNameOrIdLabel(el), 86, 'name', opts);
+    pushFormLabelCandidate(candidates, el && el.getAttribute && el.getAttribute('placeholder'), 48, 'placeholder', opts);
+    return chooseBestFormLabel(candidates) || 'Unnamed input';
   }
 
   function getLegendLabelForControl(el) {
@@ -1502,18 +1832,51 @@
     return legend ? String(textOf(legend) || '').trim() : '';
   }
 
-  function buildRadioGroupField(radios) {
+  function getRadioOptionLabel(radio, index) {
+    var candidates = [];
+    var opts = { control: radio };
+    pushFormLabelCandidate(candidates, getExplicitFormControlLabel(radio, opts), 120, 'explicit', opts);
+    pushFormLabelCandidate(candidates, radio && radio.getAttribute && radio.getAttribute('value'), 72, 'value', opts);
+    pushFormLabelCandidate(candidates, getFormNameOrIdLabel(radio), 58, 'name', opts);
+    return chooseBestFormLabel(candidates) || ('Option ' + (index + 1));
+  }
+
+  function getRadioGroupLabel(radios, options) {
     var first = radios[0];
-    var label = getLegendLabelForControl(first) || getFormControlLabel(first) || 'Choices';
+    var optionLabels = Array.isArray(options) ? options : [];
+    var blocked = new Set(optionLabels.map(function (option) {
+      return normalizeMatchText(option && option.label ? option.label : '');
+    }).filter(Boolean));
+    var sharedAncestor = getSharedAncestorForElements(radios) || first;
+    var opts = {
+      control: first,
+      blocked: blocked,
+      ignoredElements: radios,
+      boundary: getFormContainerForControl(sharedAncestor)
+    };
+    var candidates = [];
+
+    pushFormLabelCandidate(candidates, getLegendLabelForControl(first), 130, 'legend', opts);
+    pushFormLabelCandidate(candidates, readReferencedText(sharedAncestor, 'aria-labelledby'), 122, 'container_aria', opts);
+    pushFormLabelCandidate(candidates, sharedAncestor && sharedAncestor.getAttribute && sharedAncestor.getAttribute('aria-label'), 118, 'container_aria', opts);
+    collectNearbyFormLabelCandidates(sharedAncestor, opts).forEach(function (candidate) {
+      pushFormLabelCandidate(candidates, candidate.text, candidate.score, candidate.source, opts);
+    });
+    pushFormLabelCandidate(candidates, getSharedFormNameLabel(radios), 84, 'name', opts);
+    return chooseBestFormLabel(candidates) || (optionLabels[0] && optionLabels[0].label) || 'Choices';
+  }
+
+  function buildRadioGroupField(radios) {
     var required = radios.some(function (radio) { return !!(radio.hasAttribute && radio.hasAttribute('required')); });
     var options = radios.map(function (radio, index) {
-      var optionLabel = getFormControlLabel(radio) || ('Option ' + (index + 1));
+      var optionLabel = getRadioOptionLabel(radio, index);
       return {
         label: optionLabel,
         value: String((radio.getAttribute && radio.getAttribute('value')) || optionLabel),
         element: radio
       };
     });
+    var label = getRadioGroupLabel(radios, options);
     return {
       kind: 'radio',
       label: label,
@@ -3041,6 +3404,9 @@
   var voiceTurnInFlight = false;
   var voiceTurnResumeTimer = null;
   var suppressedSpeechDepth = 0;
+  var ttsPlaybackInFlight = false;
+  var ttsPlaybackToken = 0;
+  var ttsPlaybackResumeTimer = null;
 
   function clearTransientRestoreTimer() {
     if (!transientRestoreTimer) return;
@@ -3066,6 +3432,31 @@
     voiceTurnResumeTimer = null;
   }
 
+  function clearTtsPlaybackResumeTimer() {
+    if (!ttsPlaybackResumeTimer) return;
+    try { clearTimeout(ttsPlaybackResumeTimer); } catch (_err) { /* ignore */ }
+    ttsPlaybackResumeTimer = null;
+  }
+
+  function beginTtsPlayback() {
+    ttsPlaybackToken += 1;
+    clearTtsPlaybackResumeTimer();
+    ttsPlaybackInFlight = true;
+    syncListening({ announce: false });
+    return ttsPlaybackToken;
+  }
+
+  function finishTtsPlayback(token, cooldownMs) {
+    if (token !== ttsPlaybackToken) return;
+    clearTtsPlaybackResumeTimer();
+    ttsPlaybackResumeTimer = setTimeout(function () {
+      if (token !== ttsPlaybackToken) return;
+      ttsPlaybackResumeTimer = null;
+      ttsPlaybackInFlight = false;
+      syncListening({ announce: false });
+    }, Math.max(0, typeof cooldownMs === 'number' ? cooldownMs : 450));
+  }
+
   function getLiveRegion(mode) {
     var m = mode === 'assertive' ? 'assertive' : 'polite';
     return document.getElementById('navable-live-region-' + m);
@@ -3083,8 +3474,12 @@
     if (!isTransient) {
       lastSpoken = msg;
       clearTransientRestoreTimer();
-      // Rely on the ARIA live region + screen reader; do not use browser text-to-speech.
       announce(lastSpoken, { mode: mode, lang: lang });
+      return;
+    }
+
+    if (prefersChromeTtsOutput()) {
+      announce(msg, { mode: mode, lang: lang });
       return;
     }
 
@@ -3132,6 +3527,7 @@
   function computeShouldListen() {
     if (outputOpen) return false;
     if (voiceTurnInFlight) return false;
+    if (ttsPlaybackInFlight) return false;
     if (!isPageActiveForVoice()) return false;
     if (manualListening === true) return true;
     if (manualListening === false) return false;
@@ -3280,6 +3676,11 @@
     if (!recognizer) {
       if (opts.announce !== false) speak(translate('speech_not_available'));
       listening = false;
+      return;
+    }
+    if (opts.announce && prefersChromeTtsOutput()) {
+      listening = false;
+      speak(translate('listening_help'));
       return;
     }
     listening = true;
@@ -4740,7 +5141,11 @@
       return;
     }
     if (cmd.type === 'repeat') { if (lastSpoken) speak(lastSpoken); return; }
-    if (cmd.type === 'stop') { try { if (window.speechSynthesis) window.speechSynthesis.cancel(); } catch (_err) { /* cancel failed */ } return; }
+    if (cmd.type === 'stop') {
+      requestChromeTtsStop();
+      try { if (window.speechSynthesis) window.speechSynthesis.cancel(); } catch (_err) { /* cancel failed */ }
+      return;
+    }
   }
 
   async function runSummaryRequest(commandText, pageStructure) {
@@ -5018,18 +5423,22 @@
 	        var s = res && res.navable_settings ? res.navable_settings : settings;
 	        var autostart = typeof s.autostart === 'boolean' ? s.autostart : true;
 	        var nextLanguageMode = normalizeLanguageMode(s.languageMode, s.language || 'en-US');
+	        var nextOutputMode = normalizeOutputMode(s.outputMode);
 	        var nextSettings = {
 	          language: s.language || 'en-US',
 	          languageMode: nextLanguageMode,
+	          outputMode: nextOutputMode,
 	          overlay: !!s.overlay,
 	          autostart: autostart
 	        };
+	        var previousOutputMode = configuredOutputMode(settings);
 	        var nextRecogLang = configuredRecognitionLocale(nextSettings);
 	        var recogLangChanged = String(nextRecogLang).toLowerCase() !== String(recogLang || '').toLowerCase();
 	        settings = nextSettings;
 	        settingsLoaded = true;
 	        recogLang = nextRecogLang;
 	        outputLanguage = lockedOutputLanguage(settings) || normalizeOutputLanguage(settings.language || 'en-US');
+	        if (previousOutputMode !== nextOutputMode) requestChromeTtsStop();
 	        if (settings.overlay) { overlayOn = true; drawOverlay(); } else { overlayOn = false; clearOverlay(); }
 	        if (recogLangChanged) refreshRecognizer({ restart: true });
 	        else syncListening({ announce: false });
@@ -5039,18 +5448,22 @@
 	        var s2 = changes.navable_settings.newValue || settings;
 	        var autostart2 = typeof s2.autostart === 'boolean' ? s2.autostart : true;
 	        var nextLanguageMode2 = normalizeLanguageMode(s2.languageMode, s2.language || 'en-US');
+	        var nextOutputMode2 = normalizeOutputMode(s2.outputMode);
 	        var nextSettings2 = {
 	          language: s2.language || 'en-US',
 	          languageMode: nextLanguageMode2,
+	          outputMode: nextOutputMode2,
 	          overlay: !!s2.overlay,
 	          autostart: autostart2
 	        };
+	        var previousOutputMode2 = configuredOutputMode(settings);
 	        var nextRecogLang2 = configuredRecognitionLocale(nextSettings2);
 	        var recogLangChanged2 = String(nextRecogLang2).toLowerCase() !== String(recogLang || '').toLowerCase();
 	        settings = nextSettings2;
 	        settingsLoaded = true;
 	        recogLang = nextRecogLang2;
 	        outputLanguage = lockedOutputLanguage(settings) || normalizeOutputLanguage(settings.language || 'en-US');
+	        if (previousOutputMode2 !== nextOutputMode2) requestChromeTtsStop();
 	        if (settings.overlay) { overlayOn = true; drawOverlay(); } else { overlayOn = false; clearOverlay(); }
 	        if (recogLangChanged2) refreshRecognizer({ restart: true });
 	        else syncListening({ announce: false });

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -73,10 +73,30 @@ function announce(text, mode = 'polite') {
   const msg = String(text || '').trim();
   if (!msg) return;
   try {
-    if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
-      window.NavableAnnounce.speak(msg, {
-        mode: mode === 'assertive' ? 'assertive' : 'polite',
-        lang: outputLocale(currentOutputLanguage())
+    const options = {
+      mode: mode === 'assertive' ? 'assertive' : 'polite',
+      lang: outputLocale(currentOutputLanguage())
+    };
+    if (prefersNewtabChromeTtsOutput() && window.NavableAnnounce && typeof window.NavableAnnounce.output === 'function') {
+      window.NavableAnnounce.output(msg, options);
+    } else if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
+      window.NavableAnnounce.speak(msg, options);
+    } else if (window.NavableAnnounce && typeof window.NavableAnnounce.output === 'function') {
+      window.NavableAnnounce.output(msg, options);
+    }
+
+    if (prefersNewtabChromeTtsOutput()) {
+      const playbackToken = beginNewtabTtsPlayback();
+      requestNewtabChromeTtsSpeak(msg, options).then((spoken) => {
+        finishNewtabTtsPlayback(playbackToken, spoken ? 450 : 0);
+        if (spoken) return;
+        try {
+          if (window.NavableAnnounce && typeof window.NavableAnnounce.speak === 'function') {
+            window.NavableAnnounce.speak(msg, options);
+          }
+        } catch (_err2) {
+          // ignore
+        }
       });
     }
   } catch (_err) {
@@ -103,6 +123,64 @@ function normalizeLanguageMode(mode, fallbackLanguage) {
   if (!String(mode || '').trim()) return 'auto';
   const normalized = normalizeOutputLanguage(mode || fallbackLanguage || 'en-US');
   return normalized === 'ar' || normalized === 'en' ? normalized : 'auto';
+}
+
+function normalizeOutputMode(mode) {
+  const raw = String(mode || '').trim().toLowerCase();
+  if (raw === 'chrome_tts' || raw === 'chrome-tts' || raw === 'chrome tts') return 'chrome_tts';
+  return 'screen_reader';
+}
+
+function prefersNewtabChromeTtsOutput() {
+  return normalizeOutputMode(newtabOutputMode) === 'chrome_tts';
+}
+
+function requestNewtabChromeTtsSpeak(text, opts = {}) {
+  return new Promise((resolve) => {
+    const msg = String(text || '').trim();
+    if (!msg || !chrome?.runtime?.sendMessage) {
+      resolve(false);
+      return;
+    }
+    try {
+      const maybePromise = chrome.runtime.sendMessage({
+        type: 'navable:tts',
+        action: 'speak',
+        text: msg,
+        lang: opts.lang || outputLocale(currentOutputLanguage())
+      }, (response) => {
+        const lastError = chrome?.runtime?.lastError?.message ? String(chrome.runtime.lastError.message) : '';
+        if (lastError) {
+          resolve(false);
+          return;
+        }
+        resolve(!!(response && response.ok));
+      });
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        maybePromise.then((response) => {
+          resolve(!!(response && response.ok));
+        }).catch(() => {
+          resolve(false);
+        });
+      }
+    } catch (_err) {
+      resolve(false);
+    }
+  });
+}
+
+function requestNewtabChromeTtsStop() {
+  if (!chrome?.runtime?.sendMessage) return;
+  try {
+    const maybePromise = chrome.runtime.sendMessage({ type: 'navable:tts', action: 'stop' }, () => {
+      void chrome?.runtime?.lastError;
+    });
+    if (maybePromise && typeof maybePromise.catch === 'function') {
+      maybePromise.catch(() => {});
+    }
+  } catch (_err) {
+    // ignore
+  }
 }
 
 function currentLanguageMode() {
@@ -423,6 +501,7 @@ let newtabVoiceReady = false;
 let newtabVoiceLang = 'en-US';
 let newtabConfiguredVoiceLang = 'en-US';
 let newtabLanguageMode = 'auto';
+let newtabOutputMode = 'screen_reader';
 let newtabOutputLanguage = 'en';
 let newtabRecognizerRefreshTimer = null;
 let newtabLastRecognitionResultAt = 0;
@@ -430,6 +509,9 @@ let newtabLastRecognitionLocaleRotateAt = 0;
 let newtabVoiceTurnInFlight = false;
 let newtabVoiceTurnResumeTimer = null;
 let newtabPausedForVisibility = false;
+let newtabTtsPlaybackInFlight = false;
+let newtabTtsPlaybackToken = 0;
+let newtabTtsPlaybackResumeTimer = null;
 
 function clearNewtabRecognizerRefreshTimer() {
   if (!newtabRecognizerRefreshTimer) return;
@@ -451,6 +533,49 @@ function clearNewtabVoiceTurnResumeTimer() {
   newtabVoiceTurnResumeTimer = null;
 }
 
+function clearNewtabTtsPlaybackResumeTimer() {
+  if (!newtabTtsPlaybackResumeTimer) return;
+  try {
+    clearTimeout(newtabTtsPlaybackResumeTimer);
+  } catch (_err) {
+    // ignore
+  }
+  newtabTtsPlaybackResumeTimer = null;
+}
+
+function beginNewtabTtsPlayback() {
+  newtabTtsPlaybackToken += 1;
+  clearNewtabTtsPlaybackResumeTimer();
+  newtabTtsPlaybackInFlight = true;
+  const oldRecognizer = newtabRecognizer;
+  newtabRecognizer = null;
+  try {
+    oldRecognizer && oldRecognizer.stop();
+  } catch (_err) {
+    // ignore
+  }
+  refreshNewtabMicUi();
+  return newtabTtsPlaybackToken;
+}
+
+function finishNewtabTtsPlayback(token, cooldownMs = 450) {
+  if (token !== newtabTtsPlaybackToken) return;
+  clearNewtabTtsPlaybackResumeTimer();
+  newtabTtsPlaybackResumeTimer = setTimeout(() => {
+    if (token !== newtabTtsPlaybackToken) return;
+    newtabTtsPlaybackResumeTimer = null;
+    newtabTtsPlaybackInFlight = false;
+    refreshNewtabMicUi();
+    if (newtabVoiceTurnInFlight || !shouldNewtabListen()) return;
+    ensureNewtabRecognizer()
+      .then((recognizer) => {
+        if (!recognizer || newtabVoiceTurnInFlight || !shouldNewtabListen()) return;
+        recognizer.start();
+      })
+      .catch(() => {});
+  }, Math.max(0, cooldownMs));
+}
+
 function isNewtabVisibleForVoice() {
   try {
     return !document.visibilityState || document.visibilityState === 'visible';
@@ -460,7 +585,13 @@ function isNewtabVisibleForVoice() {
 }
 
 function shouldNewtabListen() {
-  return !!(newtabWantsListening && !newtabVoiceTurnInFlight && !newtabPausedForVisibility && isNewtabVisibleForVoice());
+  return !!(
+    newtabWantsListening &&
+    !newtabVoiceTurnInFlight &&
+    !newtabPausedForVisibility &&
+    !newtabTtsPlaybackInFlight &&
+    isNewtabVisibleForVoice()
+  );
 }
 
 function maybeRotateNewtabRecognitionLocale() {
@@ -514,6 +645,11 @@ function refreshNewtabMicUi() {
     status.textContent = translate('processing_request');
     return;
   }
+  if (newtabTtsPlaybackInFlight) {
+    btn.textContent = 'Speaking…';
+    status.textContent = 'Playing Navable reply…';
+    return;
+  }
   if (newtabPausedForVisibility) {
     btn.textContent = 'Listening paused';
     status.textContent = translate('listening_paused_hidden');
@@ -533,16 +669,17 @@ function setNewtabMicMessage(text, mode = 'polite') {
 async function loadNewtabVoiceSettings() {
   return new Promise((resolve) => {
     try {
-      if (!chrome?.storage?.sync?.get) return resolve({ language: 'en-US', languageMode: 'auto' });
+      if (!chrome?.storage?.sync?.get) return resolve({ language: 'en-US', languageMode: 'auto', outputMode: 'screen_reader' });
       chrome.storage.sync.get({ navable_settings: {} }, (res) => {
         const s = (res && res.navable_settings) || {};
         resolve({
           language: s.language || 'en-US',
-          languageMode: normalizeLanguageMode(s.languageMode, s.language || 'en-US')
+          languageMode: normalizeLanguageMode(s.languageMode, s.language || 'en-US'),
+          outputMode: normalizeOutputMode(s.outputMode)
         });
       });
     } catch (_err) {
-      resolve({ language: 'en-US', languageMode: 'auto' });
+      resolve({ language: 'en-US', languageMode: 'auto', outputMode: 'screen_reader' });
     }
   });
 }
@@ -551,6 +688,7 @@ async function ensureNewtabRecognizer() {
   const settings = await loadNewtabVoiceSettings();
   const previousConfiguredVoiceLang = newtabConfiguredVoiceLang;
   const previousConfiguredOutputLanguage = lockedOutputLanguage() || normalizeOutputLanguage(previousConfiguredVoiceLang || 'en-US');
+  newtabOutputMode = normalizeOutputMode(settings.outputMode);
   newtabLanguageMode = normalizeLanguageMode(settings.languageMode, settings.language || 'en-US');
   newtabConfiguredVoiceLang = (() => {
     const configured = newtabRecognitionLocaleFor(settings.language || 'en-US');
@@ -910,6 +1048,11 @@ async function startNewtabListening() {
 
   if (!shouldNewtabListen()) return;
 
+  if (prefersNewtabChromeTtsOutput()) {
+    setNewtabMicMessage(translate('newtab_listening'), 'polite');
+    return;
+  }
+
   const recognizer = await ensureNewtabRecognizer();
   if (!recognizer) {
     newtabWantsListening = false;
@@ -950,6 +1093,9 @@ async function toggleNewtabListening() {
 
 function wireNewtabVoice() {
   newtabVoiceReady = true;
+  loadNewtabVoiceSettings().then((settings) => {
+    newtabOutputMode = normalizeOutputMode(settings.outputMode);
+  }).catch(() => {});
   refreshNewtabMicUi();
 
   const { btn } = getVoiceStatusEls();
@@ -987,10 +1133,21 @@ function wireNewtabVoice() {
   window.addEventListener(
     'pagehide',
     () => {
+      requestNewtabChromeTtsStop();
       if (newtabWantsListening) stopNewtabListening({ announce: false });
     },
     { capture: true }
   );
+
+  if (chrome?.storage?.onChanged?.addListener) {
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area !== 'sync' || !changes.navable_settings) return;
+      const nextSettings = changes.navable_settings.newValue || {};
+      const nextOutputMode = normalizeOutputMode(nextSettings.outputMode);
+      if (nextOutputMode !== newtabOutputMode) requestNewtabChromeTtsStop();
+      newtabOutputMode = nextOutputMode;
+    });
+  }
 
   if (!isVoiceSupported()) {
     const { btn: btn2 } = getVoiceStatusEls();

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -61,6 +61,20 @@
             <div class="nv-options-stack">
               <div class="nv-setting-row">
                 <div class="nv-setting-copy">
+                  <h3>Reply audio</h3>
+                  <p>Choose whether Navable replies use the screen reader path or Chrome TTS. This only affects Navable output.</p>
+                </div>
+                <div class="nv-setting-control">
+                  <label class="nv-label" for="outputMode">Output mode</label>
+                  <select id="outputMode" class="nv-select">
+                    <option value="screen_reader">Screen reader</option>
+                    <option value="chrome_tts">Chrome TTS</option>
+                  </select>
+                </div>
+              </div>
+
+              <div class="nv-setting-row">
+                <div class="nv-setting-copy">
                   <h3>Conversation language</h3>
                   <p>Auto follows the user’s Arabic or English speech. Lock the mode when you want one consistent reply voice.</p>
                 </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -9,6 +9,12 @@ function normalizeLanguageMode(mode, _locale) {
   return 'auto';
 }
 
+function normalizeOutputMode(mode) {
+  const raw = String(mode || '').trim().toLowerCase();
+  if (raw === 'chrome_tts' || raw === 'chrome-tts' || raw === 'chrome tts') return 'chrome_tts';
+  return 'screen_reader';
+}
+
 function localeForLanguageMode(mode, locale) {
   const normalized = normalizeLanguageMode(mode, locale);
   const current = String(locale || '').trim();
@@ -22,6 +28,7 @@ function loadSettings() {
   chrome.storage.sync.get({ navable_settings: {} }, (res) => {
     const s = res.navable_settings || {};
     const languageMode = document.getElementById('languageMode');
+    const outputMode = document.getElementById('outputMode');
     const continuous = document.getElementById('continuous');
     const aiEnabled = document.getElementById('aiEnabled');
     const aiMode = document.getElementById('aiMode');
@@ -30,6 +37,7 @@ function loadSettings() {
 
     currentLanguageLocale = s.language || 'en-US';
     if (languageMode) languageMode.value = normalizeLanguageMode(s.languageMode, currentLanguageLocale);
+    if (outputMode) outputMode.value = normalizeOutputMode(s.outputMode);
     if (continuous) continuous.checked = typeof s.autostart === 'boolean' ? s.autostart : true;
     if (aiEnabled) aiEnabled.checked = !!s.aiEnabled;
     if (aiMode) aiMode.value = s.aiMode || 'off';
@@ -41,6 +49,7 @@ function loadSettings() {
 function saveSettings() {
   if (!chrome || !chrome.storage || !chrome.storage.sync) return;
   const languageMode = document.getElementById('languageMode');
+  const outputMode = document.getElementById('outputMode');
   const continuous = document.getElementById('continuous');
   const aiEnabled = document.getElementById('aiEnabled');
   const aiMode = document.getElementById('aiMode');
@@ -52,6 +61,7 @@ function saveSettings() {
   const navable_settings = {
     language: currentLanguageLocale,
     languageMode: normalizedLanguageMode,
+    outputMode: normalizeOutputMode(outputMode ? outputMode.value : 'screen_reader'),
     overlay: false,
     autostart: continuous ? continuous.checked : true,
     aiEnabled: aiEnabled ? aiEnabled.checked : false,
@@ -73,6 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (
       e.target &&
       (e.target.id === 'languageMode' ||
+        e.target.id === 'outputMode' ||
         e.target.id === 'continuous' ||
         e.target.id === 'aiEnabled' ||
         e.target.id === 'aiMode' ||

--- a/tests/structure-and-plan.spec.ts
+++ b/tests/structure-and-plan.spec.ts
@@ -295,6 +295,38 @@ test('runPlan executes focus/click/fill steps via tools', async ({ page }) => {
   expect(val).toBe('Navable');
 });
 
+test('runPlan resolves nearby sibling labels for inputs without explicit label wiring', async ({ page }) => {
+  await page.setContent(`
+    <main>
+      <form>
+        <div class="row">
+          <div class="label-col">Email</div>
+          <div class="input-col">
+            <input type="email" placeholder="name@example.com" />
+          </div>
+        </div>
+      </form>
+    </main>
+  `);
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+  await page.addScriptTag({ path: 'src/content.js' });
+
+  await page.waitForFunction(() => (window as any).NavableTools?.runPlan);
+
+  const res = await page.evaluate(async () => {
+    // @ts-ignore
+    return (window as any).NavableTools.runPlan({
+      steps: [
+        { action: 'fill_text', targetType: 'input', label: 'Email', value: 'hazem@example.com' }
+      ]
+    });
+  });
+
+  expect(res.ok).toBe(true);
+  const val = await page.$eval('input[type="email"]', (el) => (el as HTMLInputElement).value);
+  expect(val).toBe('hazem@example.com');
+});
+
 test('typed form mode can guide fill, select, check, and submit a form', async ({ page }) => {
   await page.setContent(`
     <main>
@@ -454,6 +486,71 @@ test('typed form mode can handle radio choice groups', async ({ page }) => {
   const confirm = await typed('yes');
   expect(confirm).toMatchObject({ ok: true });
   expect(String((confirm as any).speech || '')).toContain('That was the last field');
+});
+
+test('typed form mode review prefers semantic field labels over placeholders and option text', async ({ page }) => {
+  await page.setContent(`
+    <main>
+      <form>
+        <div class="row">
+          <div class="label-col">Email</div>
+          <div class="input-col">
+            <input type="email" value="hazemsalameh3456@gmail.com" placeholder="name@example.com" />
+          </div>
+        </div>
+        <div class="row">
+          <div class="label-col">Gender</div>
+          <div class="input-col">
+            <label><input type="radio" name="gender" value="male" /> Male</label>
+            <label><input type="radio" name="gender" value="female" /> Female</label>
+            <label><input type="radio" name="gender" value="other" checked /> Other</label>
+          </div>
+        </div>
+        <div class="row">
+          <div class="label-col">Date of Birth</div>
+          <div class="input-col">
+            <input type="text" value="15 Apr 2026" />
+          </div>
+        </div>
+      </form>
+    </main>
+  `);
+  await installTypedCommandHarness(page);
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+  await page.addScriptTag({ path: 'src/common/speech.js' });
+  await page.addScriptTag({ path: 'src/content.js' });
+
+  await page.waitForFunction(() => (window as any).__contentListeners?.length > 0);
+
+  async function typed(text: string) {
+    return await page.evaluate(async (utterance) => {
+      // @ts-ignore
+      const listener = (window as any).__contentListeners[0];
+      return await new Promise((resolve, reject) => {
+        try {
+          listener({ type: 'navable:runTypedCommand', text: utterance, detectedLanguage: 'en' }, {}, resolve);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }, text);
+  }
+
+  const start = await typed('form mode');
+  expect(start).toMatchObject({ ok: true });
+  expect(String((start as any).speech || '')).toContain('Field 1 of 3: Email');
+  expect(String((start as any).speech || '')).not.toContain('name@example.com');
+
+  const review = await typed('review form');
+  expect(review).toMatchObject({ ok: true });
+  const speech = String((review as any).speech || '');
+  expect(speech).toContain('Email: hazemsalameh3456@gmail.com');
+  expect(speech).toContain('Gender: Other');
+  expect(speech).toContain('Date of Birth: 15 Apr 2026');
+  expect(speech).not.toContain('name@example.com:');
+  expect(speech).not.toContain('Male: Other');
+  expect(speech).not.toContain('15 Apr 2026: 15 Apr 2026');
 });
 
 test('typed form mode prefers a real auth form over a small search form', async ({ page }) => {

--- a/tests/voice-lifecycle.spec.ts
+++ b/tests/voice-lifecycle.spec.ts
@@ -243,6 +243,155 @@ test('content pauses listening during a spoken turn and resumes automatically af
   expect(stats.start).toBeGreaterThanOrEqual(2);
 });
 
+test('chrome tts output keeps listening paused until playback finishes', async ({ page }) => {
+  await page.setContent(`
+    <main>
+      <h1>Voice</h1>
+      <p>Testing TTS pause.</p>
+    </main>
+  `);
+
+  await page.evaluate(() => {
+    const stats = { start: 0, stop: 0, langs: [] as string[] };
+    let resolveTts: ((value: any) => void) | null = null;
+
+    function createFakeRecognizer() {
+      const listeners: Record<string, Array<(payload?: unknown) => void>> = {
+        result: [],
+        error: [],
+        start: [],
+        end: []
+      };
+
+      return {
+        start() {
+          stats.start += 1;
+          listeners.start.forEach((fn) => fn({ provider: 'native' }));
+        },
+        stop() {
+          stats.stop += 1;
+          listeners.end.forEach((fn) => fn({ provider: 'native' }));
+        },
+        on(type: string, handler: (payload?: unknown) => void) {
+          if (!listeners[type]) listeners[type] = [];
+          listeners[type].push(handler);
+          return this;
+        }
+      };
+    }
+
+    // @ts-ignore
+    window.__speechStats = stats;
+    // @ts-ignore
+    window.__finishTts = () => {
+      if (resolveTts) {
+        resolveTts({ ok: true });
+        resolveTts = null;
+      }
+    };
+    // @ts-ignore
+    window.NavableSpeech = {
+      supportsRecognition: () => true,
+      createRecognizer: ({ lang }: { lang: string }) => {
+        stats.langs.push(String(lang || ''));
+        return createFakeRecognizer();
+      }
+    };
+    // @ts-ignore
+    window.chrome = {
+      runtime: {
+        sendMessage: (payload: any) => {
+          if (payload.type === 'planner:run') {
+            return Promise.resolve({ ok: false, unhandled: true, plan: { steps: [] } });
+          }
+          if (payload.type === 'navable:assistant') {
+            return Promise.resolve({
+              ok: true,
+              speech: "The moon is Earth's natural satellite.",
+              answer: "The moon is Earth's natural satellite.",
+              plan: { steps: [] }
+            });
+          }
+          if (payload.type === 'navable:tts' && payload.action === 'speak') {
+            return new Promise((resolve) => {
+              resolveTts = resolve;
+            });
+          }
+          if (payload.type === 'navable:tts' && payload.action === 'stop') {
+            if (resolveTts) {
+              resolveTts({ ok: true });
+              resolveTts = null;
+            }
+            return Promise.resolve({ ok: true });
+          }
+          return Promise.resolve({ ok: false });
+        },
+        onMessage: {
+          addListener() {}
+        }
+      },
+      storage: {
+        sync: {
+          get(_defaults: any, cb: (res: any) => void) {
+            cb({ navable_settings: { language: 'en-US', autostart: true, overlay: false, outputMode: 'chrome_tts' } });
+          }
+        },
+        onChanged: {
+          addListener() {}
+        }
+      }
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+  await page.addScriptTag({ path: 'src/content.js' });
+
+  await page.waitForFunction(() => (window as any).__speechStats?.start === 1);
+
+  await page.evaluate(() => {
+    // @ts-ignore
+    window.__turnPromise = (window as any).NavableTools.handleTranscript('What is the moon?', 'en', 'native');
+  });
+
+  await page.waitForFunction(() => {
+    // @ts-ignore
+    return (window.__speechStats?.stop || 0) >= 1;
+  });
+
+  await page.waitForTimeout(1300);
+
+  const beforeTtsFinishes = await page.evaluate(() => {
+    // @ts-ignore
+    return window.__speechStats;
+  });
+
+  expect(beforeTtsFinishes.start).toBe(1);
+
+  await page.evaluate(() => {
+    // @ts-ignore
+    window.__finishTts();
+  });
+
+  await page.evaluate(async () => {
+    // @ts-ignore
+    await window.__turnPromise;
+  });
+
+  await page.waitForFunction(() => {
+    // @ts-ignore
+    return (window.__speechStats?.start || 0) >= 2;
+  });
+
+  const stats = await page.evaluate(() => {
+    // @ts-ignore
+    return window.__speechStats;
+  });
+
+  expect(stats.stop).toBeGreaterThanOrEqual(1);
+  expect(stats.start).toBeGreaterThanOrEqual(2);
+});
+
 test('content resumes listening after a spoken turn even when the page loses focus', async ({ page }) => {
   await page.setContent(`
     <main>

--- a/tests/voice-qa.spec.ts
+++ b/tests/voice-qa.spec.ts
@@ -67,6 +67,95 @@ test('unknown spoken question falls back to a brief AI answer', async ({ page })
   await expect(page.locator('#navable-output-text')).toHaveValue(/Ada Lovelace/);
 });
 
+test('chrome tts mode speaks only Navable output for assistant replies', async ({ page }) => {
+  await page.setContent(`
+    <main>
+      <h1>Home</h1>
+      <p>Welcome.</p>
+    </main>
+  `);
+
+  await page.evaluate(() => {
+    window.fetch = async (url, init) => {
+      if (!String(url).includes('/api/assistant')) {
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      }
+
+      const body = JSON.parse(String(init?.body || '{}'));
+      if (body.input !== 'Who is Ada Lovelace?') {
+        throw new Error(`Unexpected input: ${String(body.input || '')}`);
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return {
+            mode: 'answer',
+            speech: 'Ada Lovelace was a mathematician who wrote the first published algorithm for a machine.',
+            summary: '',
+            answer: 'Ada Lovelace was a mathematician who wrote the first published algorithm for a machine.',
+            suggestions: [],
+            plan: { steps: [] }
+          };
+        }
+      };
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/background.js' });
+
+  await page.evaluate(() => {
+    // @ts-ignore
+    (window as any).__ttsCalls = [];
+    // @ts-ignore
+    (window as any).chrome.tts.speak = (text: string, options: any, cb?: () => void) => {
+      // @ts-ignore
+      (window as any).__ttsCalls.push({ text, lang: options?.lang || '' });
+      if (typeof cb === 'function') cb();
+      if (typeof options?.onEvent === 'function') {
+        options.onEvent({ type: 'start' });
+        options.onEvent({ type: 'end' });
+      }
+    };
+    // @ts-ignore
+    (window as any).chrome.tts.stop = () => {};
+    // @ts-ignore
+    (window as any).chrome.storage.sync.get = (_defaults: any, cb: (res: any) => void) => {
+      cb({
+        navable_settings: {
+          aiEnabled: true,
+          aiMode: 'summary',
+          language: 'en-US',
+          autostart: false,
+          outputMode: 'chrome_tts'
+        }
+      });
+    };
+  });
+
+  await page.addScriptTag({ path: 'src/common/announce.js' });
+  await page.addScriptTag({ path: 'src/common/i18n.js' });
+  await page.addScriptTag({ path: 'src/common/speech.js' });
+  await page.addScriptTag({ path: 'src/content.js' });
+
+  await page.waitForFunction(() => (window as any).NavableTools?.handleTranscript);
+
+  await page.evaluate(async () => {
+    // @ts-ignore
+    await (window as any).NavableTools.handleTranscript('Who is Ada Lovelace?', 'en');
+  });
+
+  await expect(page.locator('#navable-output-text')).toHaveValue(/Ada Lovelace/);
+
+  const ttsCalls = await page.evaluate(() => {
+    // @ts-ignore
+    return (window as any).__ttsCalls;
+  });
+
+  expect(ttsCalls.at(-1)?.text || '').toContain('Ada Lovelace');
+  await expect(page.locator('#navable-live-region-assertive')).toHaveCount(0);
+});
+
 test('short spoken questions on content tabs stay on the answer path', async ({ page }) => {
   await page.setContent(`
     <main>


### PR DESCRIPTION
## Summary
Improve semantic form labels and add Chrome TTS reply output mode

This PR contains two related accessibility and UX improvements in Navable:

1. smarter semantic form-label inference for form mode and input targeting
2. a new Chrome TTS reply-output mode, including settings support, background TTS handling, new tab integration, and regression coverage

Together, these changes make Navable’s spoken interaction clearer and more reliable on real sites with inconsistent markup, while also giving users a more direct audio-output path when they want Navable replies spoken through Chrome TTS instead of relying only on the screen-reader/live-region path.

## Why

### 1. Form labels were sometimes technically available but semantically wrong

On many sites, the DOM does not expose the user-facing field label cleanly. Common problems include:
- placeholders being used instead of real labels
- row-based layouts where the visible label is in a nearby sibling rather than in a `label for=...`
- radio groups where the option label is easy to read but the group label is separate
- `name` and `id` attributes that reflect developer terminology instead of what the user actually sees

This led to broken or confusing readback such as:
- an email field being announced as `name@example.com`
- a selected radio option being announced as if it were the field label, such as `Male: Other`

That degrades both UX and accessibility, especially in form-review mode where the spoken summary has to reflect the meaning of the field, not just any text near it.

### 2. Users needed a controllable output path for Navable replies

Navable output was effectively tied to the existing screen-reader/live-region path. That works in many cases, but it does not cover all user preferences or browser setups.

Adding Chrome TTS as an explicit reply-output mode gives users a second path for Navable-generated responses while keeping that behavior scoped to Navable output itself.

This also required making sure listening pauses during playback and resumes correctly afterward, otherwise the extension can end up hearing its own reply or reactivating too early.

## What Changed

## Smarter semantic field-label inference

Updated the form-label resolution logic in `src/content.js` and regenerated `dist/src/content.js`.

The new logic ranks candidate labels in a more user-centered order:
- explicit label associations such as `aria-labelledby`, `aria-label`, associated `<label>`, and `<legend>`
- nearby visible contextual text for row-based layouts
- shared group context for radio groups
- `name` / `id` as weaker fallbacks
- placeholder text only as a filtered last-resort fallback

The resolver now also:
- filters out example-like placeholder text such as `name@example.com`
- avoids treating field values as field labels
- separates radio-group labels from radio-option labels
- reuses the same smarter label inference for input indexing so direct field targeting also improves

### User impact

This improves:
- form review summaries
- field targeting by visible name
- grouped choice readback
- behavior on imperfect real-world forms that do not use proper explicit labeling

Example improvement:
- before: `name@example.com: hazemsalameh3456@gmail.com`
- after: `Email: hazemsalameh3456@gmail.com`

And:
- before: `Male: Other`
- after: `Gender: Other`

## Chrome TTS reply-output mode

Added a new configurable output mode so Navable replies can use Chrome TTS.

This includes:
- `tts` permission added to the extension manifest
- background service-worker support for `navable:tts` `speak` and `stop`
- content-side integration so Navable can request Chrome TTS for its own replies
- new tab integration so the new tab voice surface respects the selected output mode
- settings UI support so users can choose between `Screen reader` and `Chrome TTS`

The implementation is designed so this affects Navable output, not arbitrary page content.

## Listening lifecycle and playback coordination

To make Chrome TTS usable in practice, the voice lifecycle was updated so Navable:
- pauses listening while reply playback is active
- resumes listening after playback finishes
- stops playback when appropriate
- avoids resuming too early during a spoken response

This is important to prevent feedback loops and to preserve the turn-taking behavior of voice interactions.

## How It Works

### Form label inference

The resolver now builds a ranked set of label candidates, normalizes and cleans them, penalizes generic/example content, and chooses the highest-confidence semantic label.

For grouped radio controls, it resolves:
- the group label from legend/container/nearby context
- the option label from the option itself

This avoids mixing the two concepts.

### Chrome TTS output mode

The extension now stores an `outputMode` setting and normalizes it as either:
- `screen_reader`
- `chrome_tts`

When `chrome_tts` is selected:
- content and new tab request playback through background messaging
- the background uses `chrome.tts.speak`
- listening stays paused while playback is active
- playback can be explicitly stopped when needed

## Files / Areas Affected

### Form semantics
- `src/content.js`
- `dist/src/content.js`
- `tests/structure-and-plan.spec.ts`

### Chrome TTS output mode
- `manifest.json`
- `dist/manifest.json`
- `src/background.js`
- `dist/src/background.js`
- `src/newtab/newtab.js`
- `dist/src/newtab/newtab.js`
- `src/options/index.html`
- `dist/src/options/index.html`
- `src/options/options.js`
- `dist/src/options/options.js`
- `tests/voice-lifecycle.spec.ts`
- `tests/voice-qa.spec.ts`

## Commit Structure

This branch is split into four focused commits:

- `fix(forms): infer semantic field labels`
- `test(forms): cover semantic label fallbacks`
- `feat(audio): add chrome tts output mode`
- `test(audio): cover chrome tts output mode`

This keeps runtime behavior changes separate from regression coverage and makes review easier.

## Validation

Validated with targeted Playwright coverage for both feature sets.

### Form-label coverage
- sibling-label input targeting without explicit `label for=...`
- form review preferring semantic labels over placeholders
- radio-group review using the group label instead of the selected option label
- existing form-mode flows to guard against regressions

### Chrome TTS coverage
- Chrome TTS reply mode speaking Navable assistant output
- listening remaining paused until TTS playback completes
- automatic resume after playback finishes

## Reviewer Notes

This PR mixes two user-facing improvements from the same working tree:
- semantic correctness of spoken field labels
- audio output control for Navable replies

They are separate in implementation and commit history, but both are accessibility/voice UX improvements and both are ready for review from this branch.
