### PR TITLE
feat: add /demo/world-cup-updates page for graduation demo

### DIFF
--- a/backend/src/demo/world-cup-updates.html
+++ b/backend/src/demo/world-cup-updates.html
@@ -1,0 +1,554 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>World Cup Updates — Navable Demo</title>
+  <meta name="description" content="Controlled demonstration page for Navable voice-guided form filling. Fictitious World Cup updates signup — not affiliated with FIFA." />
+  <meta name="robots" content="noindex, nofollow" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;600;700;800&display=swap" rel="stylesheet" />
+  <style>
+    /* ── Reset & tokens ──────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --navy:       #0a1628;
+      --navy-mid:   #0d1f3c;
+      --navy-card:  #122040;
+      --navy-border:#1e3155;
+      --accent-red: #c0392b;
+      --accent-gold:#d4a017;
+      --accent-gold-light: #f0c040;
+      --white:      #ffffff;
+      --off-white:  #e8edf5;
+      --muted:      #8fa3c0;
+      --success-bg: #0d2d1a;
+      --success-border: #1e6b3a;
+      --success-text: #6ee7a0;
+      --radius-sm:  6px;
+      --radius-md:  12px;
+      --radius-lg:  20px;
+      --shadow-card: 0 8px 40px rgba(0,0,0,0.45);
+      --transition:  0.2s ease;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background-color: var(--navy);
+      color: var(--white);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0 1rem 3rem;
+      position: relative;
+      overflow-x: hidden;
+    }
+
+    /* ── Animated background mesh ───────────────────────────── */
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background:
+        radial-gradient(ellipse 80% 50% at 20% 10%, rgba(192,57,43,0.12) 0%, transparent 60%),
+        radial-gradient(ellipse 60% 40% at 80% 90%, rgba(212,160,23,0.10) 0%, transparent 60%),
+        radial-gradient(ellipse 50% 60% at 50% 50%, rgba(13,31,60,0.9) 0%, transparent 100%);
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    /* ── Layout wrapper ─────────────────────────────────────── */
+    .page-wrapper {
+      position: relative;
+      z-index: 1;
+      width: 100%;
+      max-width: 680px;
+    }
+
+    /* ── Header ─────────────────────────────────────────────── */
+    .site-header {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+    }
+
+    .badge {
+      display: inline-block;
+      background: rgba(212,160,23,0.15);
+      border: 1px solid rgba(212,160,23,0.4);
+      color: var(--accent-gold-light);
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      padding: 0.35em 0.9em;
+      border-radius: 999px;
+      margin-bottom: 1.4rem;
+    }
+
+    /* Football icon (pure CSS + SVG inline) */
+    .football-icon {
+      width: 72px;
+      height: 72px;
+      margin: 0 auto 1.4rem;
+      animation: spin-slow 12s linear infinite;
+      filter: drop-shadow(0 0 18px rgba(212,160,23,0.35));
+    }
+
+    @keyframes spin-slow {
+      from { transform: rotate(0deg); }
+      to   { transform: rotate(360deg); }
+    }
+
+    h1 {
+      font-family: 'Outfit', sans-serif;
+      font-size: clamp(1.75rem, 5vw, 2.6rem);
+      font-weight: 800;
+      line-height: 1.15;
+      background: linear-gradient(135deg, var(--white) 30%, var(--accent-gold-light) 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 0.6rem;
+    }
+
+    .subtitle {
+      font-size: 0.82rem;
+      color: var(--muted);
+      font-weight: 400;
+      letter-spacing: 0.03em;
+    }
+
+    /* ── Card ───────────────────────────────────────────────── */
+    .card {
+      background: var(--navy-card);
+      border: 1px solid var(--navy-border);
+      border-radius: var(--radius-lg);
+      padding: 2.2rem 2.4rem;
+      box-shadow: var(--shadow-card);
+      margin-top: 0.5rem;
+      transition: box-shadow var(--transition);
+    }
+
+    .card:hover {
+      box-shadow: 0 12px 60px rgba(0,0,0,0.55);
+    }
+
+    /* ── Form fields ────────────────────────────────────────── */
+    .form-group {
+      margin-bottom: 1.5rem;
+    }
+
+    label {
+      display: block;
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: var(--off-white);
+      letter-spacing: 0.04em;
+      margin-bottom: 0.5rem;
+    }
+
+    input[type="text"],
+    select {
+      width: 100%;
+      padding: 0.75rem 1rem;
+      background: var(--navy-mid);
+      border: 1.5px solid var(--navy-border);
+      border-radius: var(--radius-sm);
+      color: var(--white);
+      font-family: 'Inter', sans-serif;
+      font-size: 0.97rem;
+      outline: none;
+      transition: border-color var(--transition), box-shadow var(--transition);
+      appearance: none;
+      -webkit-appearance: none;
+    }
+
+    input[type="text"]::placeholder {
+      color: var(--muted);
+    }
+
+    input[type="text"]:focus,
+    select:focus {
+      border-color: var(--accent-gold);
+      box-shadow: 0 0 0 3px rgba(212,160,23,0.18);
+    }
+
+    /* Custom select arrow */
+    .select-wrapper {
+      position: relative;
+    }
+
+    .select-wrapper::after {
+      content: '';
+      position: absolute;
+      right: 1rem;
+      top: 50%;
+      transform: translateY(-50%);
+      border: 5px solid transparent;
+      border-top-color: var(--accent-gold);
+      pointer-events: none;
+    }
+
+    select option {
+      background: var(--navy-mid);
+      color: var(--white);
+    }
+
+    /* ── Checkbox ───────────────────────────────────────────── */
+    .checkbox-group {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.9rem 1rem;
+      background: var(--navy-mid);
+      border: 1.5px solid var(--navy-border);
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      transition: border-color var(--transition), background var(--transition);
+      margin-bottom: 1.5rem;
+    }
+
+    .checkbox-group:hover,
+    .checkbox-group:focus-within {
+      border-color: var(--accent-gold);
+      background: rgba(212,160,23,0.05);
+    }
+
+    input[type="checkbox"] {
+      width: 20px;
+      height: 20px;
+      flex-shrink: 0;
+      accent-color: var(--accent-gold);
+      cursor: pointer;
+      border-radius: 4px;
+    }
+
+    .checkbox-group label {
+      margin: 0;
+      font-size: 0.95rem;
+      font-weight: 500;
+      cursor: pointer;
+      color: var(--off-white);
+      letter-spacing: 0;
+    }
+
+    /* ── Submit button ──────────────────────────────────────── */
+    .btn-submit {
+      width: 100%;
+      padding: 0.9rem 1.5rem;
+      background: linear-gradient(135deg, #b5261c 0%, #c0392b 50%, #d4522a 100%);
+      color: #fff;
+      border: none;
+      border-radius: var(--radius-sm);
+      font-family: 'Outfit', sans-serif;
+      font-size: 1rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      cursor: pointer;
+      transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
+      box-shadow: 0 4px 20px rgba(192,57,43,0.4);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .btn-submit::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, transparent 0%, rgba(255,255,255,0.08) 100%);
+    }
+
+    .btn-submit:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 28px rgba(192,57,43,0.55);
+      filter: brightness(1.08);
+    }
+
+    .btn-submit:active {
+      transform: translateY(0);
+    }
+
+    .btn-submit:focus-visible {
+      outline: 3px solid var(--accent-gold);
+      outline-offset: 3px;
+    }
+
+    /* ── Success card ───────────────────────────────────────── */
+    #success-message {
+      background: var(--success-bg);
+      border: 1.5px solid var(--success-border);
+      border-radius: var(--radius-lg);
+      padding: 2.5rem 2rem;
+      text-align: center;
+      box-shadow: var(--shadow-card);
+      margin-top: 0.5rem;
+      animation: fade-in 0.4s ease;
+    }
+
+    @keyframes fade-in {
+      from { opacity: 0; transform: translateY(12px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    .success-icon {
+      font-size: 3rem;
+      margin-bottom: 1rem;
+      display: block;
+    }
+
+    .success-title {
+      font-family: 'Outfit', sans-serif;
+      font-size: 1.4rem;
+      font-weight: 700;
+      color: var(--success-text);
+      margin-bottom: 0.5rem;
+    }
+
+    .success-body {
+      font-size: 0.9rem;
+      color: var(--muted);
+      margin-bottom: 1.8rem;
+      line-height: 1.6;
+    }
+
+    .btn-reset {
+      display: inline-block;
+      padding: 0.7rem 2rem;
+      background: transparent;
+      border: 1.5px solid var(--success-border);
+      color: var(--success-text);
+      border-radius: var(--radius-sm);
+      font-family: 'Inter', sans-serif;
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background var(--transition), border-color var(--transition);
+    }
+
+    .btn-reset:hover {
+      background: rgba(30,107,58,0.25);
+      border-color: var(--success-text);
+    }
+
+    .btn-reset:focus-visible {
+      outline: 3px solid var(--accent-gold);
+      outline-offset: 3px;
+    }
+
+    /* ── Divider ────────────────────────────────────────────── */
+    .divider {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1.6rem;
+    }
+
+    .divider-line {
+      flex: 1;
+      height: 1px;
+      background: var(--navy-border);
+    }
+
+    .divider-text {
+      font-size: 0.75rem;
+      color: var(--muted);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+    /* ── Footer ─────────────────────────────────────────────── */
+    .site-footer {
+      text-align: center;
+      margin-top: 2.5rem;
+      font-size: 0.75rem;
+      color: var(--muted);
+      line-height: 1.7;
+    }
+
+    .site-footer strong {
+      color: var(--off-white);
+    }
+
+    /* ── Focus ring (global) ────────────────────────────────── */
+    :focus-visible {
+      outline: 3px solid var(--accent-gold);
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
+
+    /* ── Responsive ─────────────────────────────────────────── */
+    @media (max-width: 500px) {
+      .card { padding: 1.6rem 1.2rem; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page-wrapper">
+
+    <!-- ── Header ─────────────────────────────────────────── -->
+    <header class="site-header">
+      <!-- Accessible football SVG (no official FIFA branding) -->
+      <svg class="football-icon"
+           role="img"
+           aria-label="Football graphic"
+           viewBox="0 0 100 100"
+           xmlns="http://www.w3.org/2000/svg">
+        <circle cx="50" cy="50" r="46" fill="#f8f8f8" stroke="#1e3155" stroke-width="2"/>
+        <!-- Central pentagon -->
+        <polygon points="50,28 63,38 58,54 42,54 37,38"
+                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
+        <!-- Surrounding pentagons -->
+        <polygon points="50,28 63,38 72,28 65,16 50,16"
+                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
+        <polygon points="63,38 72,50 84,46 83,32 72,28"
+                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
+        <polygon points="58,54 72,50 74,64 62,72 50,66"
+                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
+        <polygon points="42,54 50,66 38,72 26,64 28,50"
+                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
+        <polygon points="37,38 28,50 16,46 17,32 28,28"
+                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
+        <polygon points="50,16 65,16 72,28 63,38 50,28 37,38 28,28 35,16"
+                 fill="none" stroke="#f8f8f8" stroke-width="1.2"/>
+      </svg>
+
+      <div class="badge">Navable Demo · Fictitious Data Only</div>
+      <h1>World Cup Updates</h1>
+      <p class="subtitle">Controlled demonstration — fictitious data only</p>
+    </header>
+
+    <!-- ── Success message (hidden by default) ────────────── -->
+    <div id="success-message"
+         role="status"
+         aria-live="polite"
+         aria-atomic="true"
+         hidden>
+      <span class="success-icon" aria-hidden="true">🏆</span>
+      <p class="success-title">You are subscribed to World Cup Updates.</p>
+      <p class="success-body">Your preferences were saved for this demonstration.</p>
+      <button id="btn-start-again" class="btn-reset" type="button">Start Again</button>
+    </div>
+
+    <!-- ── Signup form ─────────────────────────────────────── -->
+    <main>
+      <div class="card" id="form-card">
+
+        <div class="divider">
+          <span class="divider-line"></span>
+          <span class="divider-text">Sign up for updates</span>
+          <span class="divider-line"></span>
+        </div>
+
+        <form id="signup-form" novalidate autocomplete="off">
+
+          <!-- 1. Full Name -->
+          <div class="form-group">
+            <label for="full-name">Full Name</label>
+            <input
+              type="text"
+              id="full-name"
+              name="full_name"
+              placeholder="Enter your full name"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
+
+          <!-- 2. Favourite Team -->
+          <div class="form-group">
+            <label for="favourite-team">Favourite Team</label>
+            <div class="select-wrapper">
+              <select id="favourite-team" name="favourite_team">
+                <option value="">— Select a team —</option>
+                <option value="jordan">Jordan</option>
+                <option value="argentina">Argentina</option>
+                <option value="brazil">Brazil</option>
+                <option value="france">France</option>
+                <option value="spain">Spain</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- 3. Preferred Language -->
+          <div class="form-group">
+            <label for="preferred-language">Preferred Language</label>
+            <div class="select-wrapper">
+              <select id="preferred-language" name="preferred_language">
+                <option value="">— Select a language —</option>
+                <option value="english">English</option>
+                <option value="arabic">Arabic</option>
+                <option value="french">French</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- 4. Checkbox: Receive match reminders -->
+          <div class="checkbox-group">
+            <input
+              type="checkbox"
+              id="match-reminders"
+              name="match_reminders"
+            />
+            <label for="match-reminders">Receive match reminders</label>
+          </div>
+
+          <!-- 5. Submit -->
+          <button class="btn-submit" id="btn-subscribe" type="submit">
+            Subscribe for Updates
+          </button>
+
+        </form>
+      </div>
+    </main>
+
+    <!-- ── Footer ─────────────────────────────────────────── -->
+    <footer class="site-footer">
+      <p>
+        <strong>Navable</strong> · Voice-Guided Web Navigation<br />
+        This page is a controlled demo for a graduation-project presentation.<br />
+        No real data is collected. Not affiliated with FIFA or any official body.
+      </p>
+    </footer>
+
+  </div><!-- /.page-wrapper -->
+
+  <script>
+    (function () {
+      'use strict';
+
+      var form        = document.getElementById('signup-form');
+      var formCard    = document.getElementById('form-card');
+      var successMsg  = document.getElementById('success-message');
+      var btnAgain    = document.getElementById('btn-start-again');
+
+      function showSuccess() {
+        formCard.hidden = true;
+        successMsg.hidden = false;
+        successMsg.focus();
+      }
+
+      function resetDemo() {
+        form.reset();
+        successMsg.hidden = true;
+        formCard.hidden = false;
+        document.getElementById('full-name').focus();
+      }
+
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        showSuccess();
+      });
+
+      btnAgain.addEventListener('click', function () {
+        resetDemo();
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/backend/src/demo/world-cup-updates.html
+++ b/backend/src/demo/world-cup-updates.html
@@ -3,550 +3,420 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>World Cup Updates — Navable Demo</title>
-  <meta name="description" content="Controlled demonstration page for Navable voice-guided form filling. Fictitious World Cup updates signup — not affiliated with FIFA." />
+  <title>World Cup Updates &mdash; Navable Demo</title>
+  <meta
+    name="description"
+    content="Controlled fictional World Cup updates signup page for a Navable graduation-project demo."
+  />
   <meta name="robots" content="noindex, nofollow" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;600;700;800&display=swap" rel="stylesheet" />
   <style>
-    /* ── Reset & tokens ──────────────────────────────────────── */
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
     :root {
-      --navy:       #0a1628;
-      --navy-mid:   #0d1f3c;
-      --navy-card:  #122040;
-      --navy-border:#1e3155;
-      --accent-red: #c0392b;
-      --accent-gold:#d4a017;
-      --accent-gold-light: #f0c040;
-      --white:      #ffffff;
-      --off-white:  #e8edf5;
-      --muted:      #8fa3c0;
-      --success-bg: #0d2d1a;
-      --success-border: #1e6b3a;
-      --success-text: #6ee7a0;
-      --radius-sm:  6px;
-      --radius-md:  12px;
-      --radius-lg:  20px;
-      --shadow-card: 0 8px 40px rgba(0,0,0,0.45);
-      --transition:  0.2s ease;
+      --navy: #071326;
+      --navy-2: #0e2342;
+      --navy-3: #17355f;
+      --white: #ffffff;
+      --ink: #142033;
+      --muted: #5a6b81;
+      --line: #d9e2ee;
+      --gold: #d9a441;
+      --gold-soft: #fff5dd;
+      --red: #b72d2d;
+      --green: #17804d;
+      --focus: #f4c95d;
+      --shadow: 0 18px 50px rgba(0, 0, 0, 0.28);
     }
 
-    html { scroll-behavior: smooth; }
+    * {
+      box-sizing: border-box;
+    }
 
     body {
-      font-family: 'Inter', system-ui, sans-serif;
-      background-color: var(--navy);
-      color: var(--white);
+      margin: 0;
       min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      padding: 0 1rem 3rem;
-      position: relative;
-      overflow-x: hidden;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--white);
+      background:
+        radial-gradient(circle at 18% 10%, rgba(217, 164, 65, 0.2), transparent 28rem),
+        radial-gradient(circle at 86% 12%, rgba(183, 45, 45, 0.18), transparent 24rem),
+        linear-gradient(140deg, var(--navy), var(--navy-2) 55%, #08182d);
+      line-height: 1.5;
     }
 
-    /* ── Animated background mesh ───────────────────────────── */
     body::before {
-      content: '';
+      content: "";
       position: fixed;
       inset: 0;
-      background:
-        radial-gradient(ellipse 80% 50% at 20% 10%, rgba(192,57,43,0.12) 0%, transparent 60%),
-        radial-gradient(ellipse 60% 40% at 80% 90%, rgba(212,160,23,0.10) 0%, transparent 60%),
-        radial-gradient(ellipse 50% 60% at 50% 50%, rgba(13,31,60,0.9) 0%, transparent 100%);
       pointer-events: none;
-      z-index: 0;
+      background-image:
+        linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+      background-size: 44px 44px;
+      mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent 75%);
     }
 
-    /* ── Layout wrapper ─────────────────────────────────────── */
-    .page-wrapper {
+    .page {
       position: relative;
-      z-index: 1;
-      width: 100%;
-      max-width: 680px;
+      width: min(100%, 1080px);
+      margin: 0 auto;
+      padding: 40px 20px;
     }
 
-    /* ── Header ─────────────────────────────────────────────── */
-    .site-header {
-      text-align: center;
-      padding: 3rem 1rem 2rem;
+    .hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 92px;
+      gap: 24px;
+      align-items: center;
+      margin: 0 0 28px;
     }
 
-    .badge {
-      display: inline-block;
-      background: rgba(212,160,23,0.15);
-      border: 1px solid rgba(212,160,23,0.4);
-      color: var(--accent-gold-light);
-      font-size: 0.72rem;
-      font-weight: 600;
+    .kicker {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      margin: 0 0 14px;
+      color: var(--gold);
+      font-size: 0.78rem;
+      font-weight: 800;
       letter-spacing: 0.12em;
       text-transform: uppercase;
-      padding: 0.35em 0.9em;
+    }
+
+    .kicker::before {
+      content: "";
+      width: 34px;
+      height: 3px;
+      background: var(--red);
       border-radius: 999px;
-      margin-bottom: 1.4rem;
-    }
-
-    /* Football icon (pure CSS + SVG inline) */
-    .football-icon {
-      width: 72px;
-      height: 72px;
-      margin: 0 auto 1.4rem;
-      animation: spin-slow 12s linear infinite;
-      filter: drop-shadow(0 0 18px rgba(212,160,23,0.35));
-    }
-
-    @keyframes spin-slow {
-      from { transform: rotate(0deg); }
-      to   { transform: rotate(360deg); }
     }
 
     h1 {
-      font-family: 'Outfit', sans-serif;
-      font-size: clamp(1.75rem, 5vw, 2.6rem);
-      font-weight: 800;
-      line-height: 1.15;
-      background: linear-gradient(135deg, var(--white) 30%, var(--accent-gold-light) 100%);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-      margin-bottom: 0.6rem;
+      margin: 0;
+      font-size: clamp(2rem, 7vw, 4.2rem);
+      line-height: 1;
+      letter-spacing: 0;
     }
 
     .subtitle {
-      font-size: 0.82rem;
-      color: var(--muted);
-      font-weight: 400;
-      letter-spacing: 0.03em;
+      margin: 14px 0 0;
+      color: #dce7f5;
+      font-size: clamp(1rem, 2.6vw, 1.2rem);
     }
 
-    /* ── Card ───────────────────────────────────────────────── */
+    .ball {
+      width: 92px;
+      height: 92px;
+      filter: drop-shadow(0 14px 20px rgba(0, 0, 0, 0.28));
+    }
+
+    .content {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 320px;
+      gap: 22px;
+      align-items: start;
+    }
+
     .card {
-      background: var(--navy-card);
-      border: 1px solid var(--navy-border);
-      border-radius: var(--radius-lg);
-      padding: 2.2rem 2.4rem;
-      box-shadow: var(--shadow-card);
-      margin-top: 0.5rem;
-      transition: box-shadow var(--transition);
+      background: var(--white);
+      color: var(--ink);
+      border: 1px solid rgba(255, 255, 255, 0.65);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
     }
 
-    .card:hover {
-      box-shadow: 0 12px 60px rgba(0,0,0,0.55);
+    .form-card {
+      padding: clamp(22px, 5vw, 36px);
     }
 
-    /* ── Form fields ────────────────────────────────────────── */
-    .form-group {
-      margin-bottom: 1.5rem;
+    .panel-title {
+      margin: 0 0 22px;
+      padding-bottom: 16px;
+      border-bottom: 1px solid var(--line);
+      color: var(--ink);
+      font-size: 1.05rem;
+      font-weight: 800;
+    }
+
+    .field {
+      margin: 0 0 20px;
     }
 
     label {
       display: block;
-      font-size: 0.82rem;
-      font-weight: 600;
-      color: var(--off-white);
-      letter-spacing: 0.04em;
-      margin-bottom: 0.5rem;
+      margin: 0 0 8px;
+      color: var(--ink);
+      font-size: 0.95rem;
+      font-weight: 750;
     }
 
     input[type="text"],
     select {
+      display: block;
       width: 100%;
-      padding: 0.75rem 1rem;
-      background: var(--navy-mid);
-      border: 1.5px solid var(--navy-border);
-      border-radius: var(--radius-sm);
-      color: var(--white);
-      font-family: 'Inter', sans-serif;
-      font-size: 0.97rem;
-      outline: none;
-      transition: border-color var(--transition), box-shadow var(--transition);
-      appearance: none;
-      -webkit-appearance: none;
+      min-height: 48px;
+      padding: 10px 12px;
+      color: var(--ink);
+      background: #fbfdff;
+      border: 1px solid #b8c6d8;
+      border-radius: 6px;
+      font: inherit;
     }
 
     input[type="text"]::placeholder {
-      color: var(--muted);
+      color: #8493a7;
     }
 
     input[type="text"]:focus,
-    select:focus {
-      border-color: var(--accent-gold);
-      box-shadow: 0 0 0 3px rgba(212,160,23,0.18);
+    select:focus,
+    input[type="checkbox"]:focus-visible,
+    button:focus-visible {
+      outline: 3px solid var(--focus);
+      outline-offset: 3px;
+      border-color: var(--navy-3);
     }
 
-    /* Custom select arrow */
-    .select-wrapper {
-      position: relative;
-    }
-
-    .select-wrapper::after {
-      content: '';
-      position: absolute;
-      right: 1rem;
-      top: 50%;
-      transform: translateY(-50%);
-      border: 5px solid transparent;
-      border-top-color: var(--accent-gold);
-      pointer-events: none;
-    }
-
-    select option {
-      background: var(--navy-mid);
-      color: var(--white);
-    }
-
-    /* ── Checkbox ───────────────────────────────────────────── */
-    .checkbox-group {
+    .checkbox-row {
       display: flex;
       align-items: center;
-      gap: 0.75rem;
-      padding: 0.9rem 1rem;
-      background: var(--navy-mid);
-      border: 1.5px solid var(--navy-border);
-      border-radius: var(--radius-sm);
-      cursor: pointer;
-      transition: border-color var(--transition), background var(--transition);
-      margin-bottom: 1.5rem;
+      gap: 12px;
+      margin: 2px 0 24px;
+      padding: 14px;
+      background: var(--gold-soft);
+      border: 1px solid #efd79b;
+      border-radius: 6px;
     }
 
-    .checkbox-group:hover,
-    .checkbox-group:focus-within {
-      border-color: var(--accent-gold);
-      background: rgba(212,160,23,0.05);
-    }
-
-    input[type="checkbox"] {
-      width: 20px;
-      height: 20px;
-      flex-shrink: 0;
-      accent-color: var(--accent-gold);
-      cursor: pointer;
-      border-radius: 4px;
-    }
-
-    .checkbox-group label {
+    .checkbox-row input {
+      width: 22px;
+      height: 22px;
       margin: 0;
-      font-size: 0.95rem;
-      font-weight: 500;
-      cursor: pointer;
-      color: var(--off-white);
-      letter-spacing: 0;
+      accent-color: var(--gold);
+      flex: 0 0 auto;
     }
 
-    /* ── Submit button ──────────────────────────────────────── */
-    .btn-submit {
-      width: 100%;
-      padding: 0.9rem 1.5rem;
-      background: linear-gradient(135deg, #b5261c 0%, #c0392b 50%, #d4522a 100%);
-      color: #fff;
-      border: none;
-      border-radius: var(--radius-sm);
-      font-family: 'Outfit', sans-serif;
-      font-size: 1rem;
+    .checkbox-row label {
+      margin: 0;
       font-weight: 700;
-      letter-spacing: 0.04em;
+    }
+
+    button {
+      min-height: 48px;
+      border: 0;
+      border-radius: 6px;
+      font: inherit;
+      font-weight: 800;
       cursor: pointer;
-      transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
-      box-shadow: 0 4px 20px rgba(192,57,43,0.4);
-      position: relative;
-      overflow: hidden;
     }
 
-    .btn-submit::after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(135deg, transparent 0%, rgba(255,255,255,0.08) 100%);
+    .submit-button {
+      width: 100%;
+      color: var(--white);
+      background: linear-gradient(135deg, var(--red), #8f2020);
+      box-shadow: 0 10px 20px rgba(183, 45, 45, 0.24);
     }
 
-    .btn-submit:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 8px 28px rgba(192,57,43,0.55);
-      filter: brightness(1.08);
+    .submit-button:hover {
+      background: linear-gradient(135deg, #c53838, #8f2020);
     }
 
-    .btn-submit:active {
-      transform: translateY(0);
+    .note-card {
+      padding: 24px;
+      border-top: 5px solid var(--gold);
     }
 
-    .btn-submit:focus-visible {
-      outline: 3px solid var(--accent-gold);
-      outline-offset: 3px;
+    .note-card p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.95rem;
     }
 
-    /* ── Success card ───────────────────────────────────────── */
-    #success-message {
-      background: var(--success-bg);
-      border: 1.5px solid var(--success-border);
-      border-radius: var(--radius-lg);
-      padding: 2.5rem 2rem;
-      text-align: center;
-      box-shadow: var(--shadow-card);
-      margin-top: 0.5rem;
-      animation: fade-in 0.4s ease;
-    }
-
-    @keyframes fade-in {
-      from { opacity: 0; transform: translateY(12px); }
-      to   { opacity: 1; transform: translateY(0); }
-    }
-
-    .success-icon {
-      font-size: 3rem;
-      margin-bottom: 1rem;
+    .note-card strong {
       display: block;
+      margin: 0 0 8px;
+      color: var(--ink);
+      font-size: 1rem;
+    }
+
+    .success-card {
+      padding: clamp(24px, 5vw, 40px);
+      text-align: center;
+      border-top: 5px solid var(--green);
+    }
+
+    .success-mark {
+      display: inline-grid;
+      place-items: center;
+      width: 56px;
+      height: 56px;
+      margin: 0 0 16px;
+      color: var(--white);
+      background: var(--green);
+      border-radius: 50%;
+      font-size: 1.6rem;
+      font-weight: 900;
+    }
+
+    .success-card p {
+      margin: 0;
     }
 
     .success-title {
-      font-family: 'Outfit', sans-serif;
-      font-size: 1.4rem;
-      font-weight: 700;
-      color: var(--success-text);
-      margin-bottom: 0.5rem;
+      color: var(--ink);
+      font-size: 1.35rem;
+      font-weight: 850;
     }
 
     .success-body {
-      font-size: 0.9rem;
+      margin-top: 8px;
       color: var(--muted);
-      margin-bottom: 1.8rem;
-      line-height: 1.6;
     }
 
-    .btn-reset {
-      display: inline-block;
-      padding: 0.7rem 2rem;
-      background: transparent;
-      border: 1.5px solid var(--success-border);
-      color: var(--success-text);
-      border-radius: var(--radius-sm);
-      font-family: 'Inter', sans-serif;
-      font-size: 0.9rem;
-      font-weight: 600;
-      cursor: pointer;
-      transition: background var(--transition), border-color var(--transition);
+    .start-again {
+      margin-top: 24px;
+      padding: 0 22px;
+      color: var(--white);
+      background: var(--navy-3);
     }
 
-    .btn-reset:hover {
-      background: rgba(30,107,58,0.25);
-      border-color: var(--success-text);
+    .start-again:hover {
+      background: var(--navy-2);
     }
 
-    .btn-reset:focus-visible {
-      outline: 3px solid var(--accent-gold);
-      outline-offset: 3px;
+    footer {
+      margin: 26px 0 0;
+      color: #c8d5e7;
+      font-size: 0.88rem;
     }
 
-    /* ── Divider ────────────────────────────────────────────── */
-    .divider {
-      display: flex;
-      align-items: center;
-      gap: 1rem;
-      margin-bottom: 1.6rem;
-    }
+    @media (max-width: 760px) {
+      .page {
+        padding: 28px 16px;
+      }
 
-    .divider-line {
-      flex: 1;
-      height: 1px;
-      background: var(--navy-border);
-    }
+      .hero,
+      .content {
+        grid-template-columns: 1fr;
+      }
 
-    .divider-text {
-      font-size: 0.75rem;
-      color: var(--muted);
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      white-space: nowrap;
-    }
-
-    /* ── Footer ─────────────────────────────────────────────── */
-    .site-footer {
-      text-align: center;
-      margin-top: 2.5rem;
-      font-size: 0.75rem;
-      color: var(--muted);
-      line-height: 1.7;
-    }
-
-    .site-footer strong {
-      color: var(--off-white);
-    }
-
-    /* ── Focus ring (global) ────────────────────────────────── */
-    :focus-visible {
-      outline: 3px solid var(--accent-gold);
-      outline-offset: 2px;
-      border-radius: 2px;
-    }
-
-    /* ── Responsive ─────────────────────────────────────────── */
-    @media (max-width: 500px) {
-      .card { padding: 1.6rem 1.2rem; }
+      .ball {
+        width: 74px;
+        height: 74px;
+      }
     }
   </style>
 </head>
 <body>
-  <div class="page-wrapper">
+  <div class="page">
+    <header class="hero">
+      <div>
+        <p class="kicker">Navable Demo</p>
+        <h1>World Cup Updates</h1>
+        <p class="subtitle">Controlled demonstration &mdash; fictitious data only</p>
+      </div>
 
-    <!-- ── Header ─────────────────────────────────────────── -->
-    <header class="site-header">
-      <!-- Accessible football SVG (no official FIFA branding) -->
-      <svg class="football-icon"
-           role="img"
-           aria-label="Football graphic"
-           viewBox="0 0 100 100"
-           xmlns="http://www.w3.org/2000/svg">
-        <circle cx="50" cy="50" r="46" fill="#f8f8f8" stroke="#1e3155" stroke-width="2"/>
-        <!-- Central pentagon -->
-        <polygon points="50,28 63,38 58,54 42,54 37,38"
-                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
-        <!-- Surrounding pentagons -->
-        <polygon points="50,28 63,38 72,28 65,16 50,16"
-                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
-        <polygon points="63,38 72,50 84,46 83,32 72,28"
-                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
-        <polygon points="58,54 72,50 74,64 62,72 50,66"
-                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
-        <polygon points="42,54 50,66 38,72 26,64 28,50"
-                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
-        <polygon points="37,38 28,50 16,46 17,32 28,28"
-                 fill="#1a2a4a" stroke="#f8f8f8" stroke-width="1.2"/>
-        <polygon points="50,16 65,16 72,28 63,38 50,28 37,38 28,28 35,16"
-                 fill="none" stroke="#f8f8f8" stroke-width="1.2"/>
+      <svg
+        class="ball"
+        role="img"
+        aria-label="Football graphic"
+        viewBox="0 0 100 100"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle cx="50" cy="50" r="46" fill="#ffffff" stroke="#d9a441" stroke-width="4" />
+        <polygon points="50,25 65,36 59,54 41,54 35,36" fill="#142033" />
+        <path d="M50 25V9M65 36l18-7M59 54l12 18M41 54L29 72M35 36L17 29" stroke="#142033" stroke-width="4" stroke-linecap="round" />
+        <path d="M50 9a46 46 0 0 1 33 20M83 29a46 46 0 0 1-12 43M71 72a46 46 0 0 1-42 0M29 72a46 46 0 0 1-12-43M17 29A46 46 0 0 1 50 9" fill="none" stroke="#142033" stroke-width="4" stroke-linecap="round" />
       </svg>
-
-      <div class="badge">Navable Demo · Fictitious Data Only</div>
-      <h1>World Cup Updates</h1>
-      <p class="subtitle">Controlled demonstration — fictitious data only</p>
     </header>
 
-    <!-- ── Success message (hidden by default) ────────────── -->
-    <div id="success-message"
-         role="status"
-         aria-live="polite"
-         aria-atomic="true"
-         hidden>
-      <span class="success-icon" aria-hidden="true">🏆</span>
-      <p class="success-title">You are subscribed to World Cup Updates.</p>
-      <p class="success-body">Your preferences were saved for this demonstration.</p>
-      <button id="btn-start-again" class="btn-reset" type="button">Start Again</button>
-    </div>
+    <main class="content">
+      <section class="card form-card" id="form-card" aria-labelledby="form-heading">
+        <h2 class="panel-title" id="form-heading">Update preferences</h2>
 
-    <!-- ── Signup form ─────────────────────────────────────── -->
-    <main>
-      <div class="card" id="form-card">
-
-        <div class="divider">
-          <span class="divider-line"></span>
-          <span class="divider-text">Sign up for updates</span>
-          <span class="divider-line"></span>
-        </div>
-
-        <form id="signup-form" novalidate autocomplete="off">
-
-          <!-- 1. Full Name -->
-          <div class="form-group">
+        <form id="updates-form" autocomplete="off">
+          <div class="field">
             <label for="full-name">Full Name</label>
             <input
-              type="text"
               id="full-name"
               name="full_name"
-              placeholder="Enter your full name"
-              autocomplete="off"
+              type="text"
+              placeholder="Hazem Salameh"
               spellcheck="false"
             />
           </div>
 
-          <!-- 2. Favourite Team -->
-          <div class="form-group">
+          <div class="field">
             <label for="favourite-team">Favourite Team</label>
-            <div class="select-wrapper">
-              <select id="favourite-team" name="favourite_team">
-                <option value="">— Select a team —</option>
-                <option value="jordan">Jordan</option>
-                <option value="argentina">Argentina</option>
-                <option value="brazil">Brazil</option>
-                <option value="france">France</option>
-                <option value="spain">Spain</option>
-              </select>
-            </div>
+            <select id="favourite-team" name="favourite_team">
+              <option value="Jordan">Jordan</option>
+              <option value="Argentina">Argentina</option>
+              <option value="Brazil">Brazil</option>
+              <option value="France">France</option>
+              <option value="Spain">Spain</option>
+            </select>
           </div>
 
-          <!-- 3. Preferred Language -->
-          <div class="form-group">
+          <div class="field">
             <label for="preferred-language">Preferred Language</label>
-            <div class="select-wrapper">
-              <select id="preferred-language" name="preferred_language">
-                <option value="">— Select a language —</option>
-                <option value="english">English</option>
-                <option value="arabic">Arabic</option>
-                <option value="french">French</option>
-              </select>
-            </div>
+            <select id="preferred-language" name="preferred_language">
+              <option value="English">English</option>
+              <option value="Arabic">Arabic</option>
+              <option value="French">French</option>
+            </select>
           </div>
 
-          <!-- 4. Checkbox: Receive match reminders -->
-          <div class="checkbox-group">
-            <input
-              type="checkbox"
-              id="match-reminders"
-              name="match_reminders"
-            />
+          <div class="checkbox-row">
+            <input id="match-reminders" name="match_reminders" type="checkbox" />
             <label for="match-reminders">Receive match reminders</label>
           </div>
 
-          <!-- 5. Submit -->
-          <button class="btn-submit" id="btn-subscribe" type="submit">
-            Subscribe for Updates
-          </button>
-
+          <button class="submit-button" type="submit">Subscribe for Updates</button>
         </form>
-      </div>
+      </section>
+
+      <aside class="card note-card" aria-label="Demo notice">
+        <strong>Fictional demo page</strong>
+        <p>This page is not affiliated with FIFA or any official tournament body. It is only for a controlled Navable presentation.</p>
+      </aside>
+
+      <section
+        class="card success-card"
+        id="success-message"
+        aria-live="polite"
+        aria-atomic="true"
+        tabindex="-1"
+        hidden
+      >
+        <span class="success-mark" aria-hidden="true">✓</span>
+        <p class="success-title">You are subscribed to World Cup Updates.</p>
+        <p class="success-body">Your preferences were saved for this demonstration.</p>
+        <button class="start-again" id="start-again" type="button">Start Again</button>
+      </section>
     </main>
 
-    <!-- ── Footer ─────────────────────────────────────────── -->
-    <footer class="site-footer">
-      <p>
-        <strong>Navable</strong> · Voice-Guided Web Navigation<br />
-        This page is a controlled demo for a graduation-project presentation.<br />
-        No real data is collected. Not affiliated with FIFA or any official body.
-      </p>
+    <footer>
+      Controlled demonstration page. No real data is collected.
     </footer>
-
-  </div><!-- /.page-wrapper -->
+  </div>
 
   <script>
     (function () {
-      'use strict';
+      var form = document.getElementById('updates-form');
+      var formCard = document.getElementById('form-card');
+      var successMessage = document.getElementById('success-message');
+      var startAgainButton = document.getElementById('start-again');
+      var firstField = document.getElementById('full-name');
 
-      var form        = document.getElementById('signup-form');
-      var formCard    = document.getElementById('form-card');
-      var successMsg  = document.getElementById('success-message');
-      var btnAgain    = document.getElementById('btn-start-again');
-
-      function showSuccess() {
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
         formCard.hidden = true;
-        successMsg.hidden = false;
-        successMsg.focus();
-      }
-
-      function resetDemo() {
-        form.reset();
-        successMsg.hidden = true;
-        formCard.hidden = false;
-        document.getElementById('full-name').focus();
-      }
-
-      form.addEventListener('submit', function (e) {
-        e.preventDefault();
-        showSuccess();
+        successMessage.hidden = false;
+        successMessage.focus();
       });
 
-      btnAgain.addEventListener('click', function () {
-        resetDemo();
+      startAgainButton.addEventListener('click', function () {
+        form.reset();
+        successMessage.hidden = true;
+        formCard.hidden = false;
+        firstField.focus();
       });
     })();
   </script>

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -782,6 +782,22 @@ async function callOpenAiTranscribe(audioBase64, mimeType, settings = DEFAULT_SE
   };
 }
 
+// ── Demo page (graduation presentation only) ─────────────────────────────────
+// Serves a static World Cup sign-up demo page.  Completely isolated from all
+// AI/voice/extension logic — just a plain HTML file on disk.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+app.get('/demo/world-cup-updates', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'demo', 'world-cup-updates.html'));
+});
+
+// Also allow the .html variant so both paths work.
+app.get('/demo/world-cup-updates.html', (_req, res) => {
+  res.redirect(301, '/demo/world-cup-updates');
+});
+// ── End demo page ─────────────────────────────────────────────────────────────
+
 app.get('/health', (_req, res) => {
   res.json({ ok: true });
 });


### PR DESCRIPTION
## Summary

Adds a controlled demo page for the Navable graduation-project presentation.

### What changed
- **`backend/src/demo/world-cup-updates.html`** *(new)* — Self-contained, fully accessible World Cup signup form. No external dependencies. Pure semantic HTML + CSS + minimal JS.
- **`backend/src/server.js`** *(modified)* — Adds two routes:
  - `GET /demo/world-cup-updates` → serves the HTML file via `res.sendFile`
  - `GET /demo/world-cup-updates.html` → 301 redirect to the canonical URL

### What was NOT changed
- No AI logic, no voice parser, no transcription routes, no extension source files.
- No external dependencies added.
- The HTML file is automatically included in the Docker image because the Dockerfile already does `COPY src ./src`.

### Deployment
After merge, Render will auto-deploy (per `autoDeployTrigger: commit` in render.yaml).
Final URL: **https://navable.onrender.com/demo/world-cup-updates**

### Voice command for demo
> *"Open navable.onrender.com/demo/world-cup-updates"*