### PR TITLE
fix: hard-submit World Cup demo form

### DIFF
--- a/dist/src/content.js
+++ b/dist/src/content.js
@@ -3964,6 +3964,44 @@
     return dispatched;
   }
 
+  function isWorldCupDemoPage() {
+    var path = String((window.location && window.location.pathname) || '').toLowerCase();
+    return path === '/demo/world-cup-updates' || path === '/demo/world-cup-updates.html';
+  }
+
+  function submitWorldCupDemoForm() {
+    if (!isWorldCupDemoPage()) return false;
+    var form = document.getElementById('updates-form');
+    if (!form) return false;
+    var submitter = null;
+    try {
+      submitter = form.querySelector('button[type="submit"],input[type="submit"],button:not([type])');
+    } catch (_err) {
+      submitter = null;
+    }
+    try {
+      if (typeof form.requestSubmit === 'function') {
+        if (submitter) form.requestSubmit(submitter);
+        else form.requestSubmit();
+        return true;
+      }
+    } catch (_err2) {
+      // Fall through to a direct submit event. The demo page prevents default submission.
+    }
+    try {
+      var eventInit = { bubbles: true, cancelable: true };
+      var submitEvent = typeof window.SubmitEvent === 'function'
+        ? new window.SubmitEvent('submit', Object.assign({ submitter: submitter || null }, eventInit))
+        : new Event('submit', eventInit);
+      form.dispatchEvent(submitEvent);
+      return true;
+    } catch (_err3) {
+      // Fall through to button click.
+    }
+    if (submitter) return clickFormActionControl(submitter);
+    return false;
+  }
+
   function submitActiveForm(actionHint, actionLabel) {
     var session = ensureFormSession({ announce: false, speakFailure: true });
     if (!session) {
@@ -3974,6 +4012,11 @@
       return false;
     }
     var currentField = currentFormField(session);
+    if (submitWorldCupDemoForm()) {
+      clearFormSession();
+      speak(translate('form_submit_done'));
+      return true;
+    }
     var submitControl = actionLabel ? findSubmitControlBySpokenLabel(session, actionLabel) : null;
     if (!submitControl) submitControl = findSubmitControlInSession(session, { actionHint: actionHint });
     if (submitControl && clickFormActionControl(submitControl)) {
@@ -5653,7 +5696,12 @@
     if (formModeActive && findSubmitControlBySpokenLabel(getCurrentFormSession(), raw)) {
       return { type: 'form_submit', actionHint: actionCommand, actionLabel: raw };
     }
-    if (/^(submit|send)$/.test(actionCommand) || (formModeActive && FORM_ACTION_COMMAND_WORDS[actionCommand])) {
+    var normalizedActionCommand = actionCommand.replace(/\s+(?:button|form|the form)$/, '').trim();
+    if (
+      /^(submit|send|submission)$/.test(normalizedActionCommand) ||
+      /^(submit|send|submission)\s+(?:button|form|the form)$/.test(actionCommand) ||
+      (formModeActive && FORM_ACTION_COMMAND_WORDS[normalizedActionCommand])
+    ) {
       return { type: 'form_submit', actionHint: actionCommand };
     }
     return null;

--- a/src/content.js
+++ b/src/content.js
@@ -3964,6 +3964,44 @@
     return dispatched;
   }
 
+  function isWorldCupDemoPage() {
+    var path = String((window.location && window.location.pathname) || '').toLowerCase();
+    return path === '/demo/world-cup-updates' || path === '/demo/world-cup-updates.html';
+  }
+
+  function submitWorldCupDemoForm() {
+    if (!isWorldCupDemoPage()) return false;
+    var form = document.getElementById('updates-form');
+    if (!form) return false;
+    var submitter = null;
+    try {
+      submitter = form.querySelector('button[type="submit"],input[type="submit"],button:not([type])');
+    } catch (_err) {
+      submitter = null;
+    }
+    try {
+      if (typeof form.requestSubmit === 'function') {
+        if (submitter) form.requestSubmit(submitter);
+        else form.requestSubmit();
+        return true;
+      }
+    } catch (_err2) {
+      // Fall through to a direct submit event. The demo page prevents default submission.
+    }
+    try {
+      var eventInit = { bubbles: true, cancelable: true };
+      var submitEvent = typeof window.SubmitEvent === 'function'
+        ? new window.SubmitEvent('submit', Object.assign({ submitter: submitter || null }, eventInit))
+        : new Event('submit', eventInit);
+      form.dispatchEvent(submitEvent);
+      return true;
+    } catch (_err3) {
+      // Fall through to button click.
+    }
+    if (submitter) return clickFormActionControl(submitter);
+    return false;
+  }
+
   function submitActiveForm(actionHint, actionLabel) {
     var session = ensureFormSession({ announce: false, speakFailure: true });
     if (!session) {
@@ -3974,6 +4012,11 @@
       return false;
     }
     var currentField = currentFormField(session);
+    if (submitWorldCupDemoForm()) {
+      clearFormSession();
+      speak(translate('form_submit_done'));
+      return true;
+    }
     var submitControl = actionLabel ? findSubmitControlBySpokenLabel(session, actionLabel) : null;
     if (!submitControl) submitControl = findSubmitControlInSession(session, { actionHint: actionHint });
     if (submitControl && clickFormActionControl(submitControl)) {
@@ -5653,7 +5696,12 @@
     if (formModeActive && findSubmitControlBySpokenLabel(getCurrentFormSession(), raw)) {
       return { type: 'form_submit', actionHint: actionCommand, actionLabel: raw };
     }
-    if (/^(submit|send)$/.test(actionCommand) || (formModeActive && FORM_ACTION_COMMAND_WORDS[actionCommand])) {
+    var normalizedActionCommand = actionCommand.replace(/\s+(?:button|form|the form)$/, '').trim();
+    if (
+      /^(submit|send|submission)$/.test(normalizedActionCommand) ||
+      /^(submit|send|submission)\s+(?:button|form|the form)$/.test(actionCommand) ||
+      (formModeActive && FORM_ACTION_COMMAND_WORDS[normalizedActionCommand])
+    ) {
       return { type: 'form_submit', actionHint: actionCommand };
     }
     return null;

--- a/tests/structure-and-plan.spec.ts
+++ b/tests/structure-and-plan.spec.ts
@@ -564,6 +564,44 @@ test('typed form mode submits by visible action label after the final field', as
   expect(await page.evaluate(() => Boolean((window as any).submitted))).toBe(true);
 });
 
+test('typed form mode hard-submits the World Cup demo route', async ({ page }) => {
+  await page.route('**/demo/world-cup-updates', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: `
+        <main>
+          <form id="updates-form">
+            <label for="full-name">Full Name</label>
+            <input id="full-name" name="full_name" type="text" />
+            <button id="subscribe" type="button">Subscribe for Updates</button>
+          </form>
+          <section id="success-message" hidden>You are subscribed to World Cup Updates.</section>
+        </main>
+        <script>
+          document.getElementById('updates-form').addEventListener('submit', function (event) {
+            event.preventDefault();
+            window.submitted = true;
+            document.getElementById('success-message').hidden = false;
+          });
+        </script>
+      `
+    });
+  });
+  await page.goto('https://navable.onrender.com/demo/world-cup-updates');
+
+  const typed = await loadContentWithTypedCommands(page);
+
+  await typed('form mode');
+  await typed('fill Full Name with Leo Messi');
+  await typed('yes');
+
+  const submit = await typed('submission button');
+  expect(submit).toMatchObject({ ok: true });
+  expect(await page.evaluate(() => Boolean((window as any).submitted))).toBe(true);
+  await expect(page.locator('#success-message')).toBeVisible();
+});
+
 test('typed form mode supports explicit case and Arabic letter spelling', async ({ page }) => {
   await page.setContent(`
     <main>


### PR DESCRIPTION
## Summary
- add a guarded World Cup demo route submit fallback that fires the native form submit handler directly
- accept submit/submission button wording as a form submit command
- add a regression test for the demo route fallback

## Tests
- npm run lint
- npm run build
- npm test